### PR TITLE
fix(build): can run karam and karma:watch on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build:clean": "rimraf dist",
     "build:webpack": "webpack --progress --colors --config build/webpack.dist.babel.js",
     "build:watch": "webpack --progress --colors --config build/webpack.dist.babel.js --watch",
-    "karma": "cross-env NODE_ENV=test babel-node $(npm bin)/karma start build/karma.conf.js --reporters nyan,coverage --single-run",
-    "karma:watch": "cross-env NODE_ENV=test BABEL_ENV=test node -r babel-register $(npm bin)/karma start build/karma.conf.js --watch"
+    "karma": "cross-env NODE_ENV=test babel-node node_modules/karma/bin/karma start build/karma.conf.js --reporters nyan,coverage --single-run",
+    "karma:watch": "cross-env NODE_ENV=test BABEL_ENV=test node -r babel-register node_modules/karma/bin/karma start build/karma.conf.js --watch"
   },
   "dependencies": {
     "ovh-ui-kit": "https://github.com/ovh-ux/ovh-ui-kit.git"


### PR DESCRIPTION
Signed-off-by: Jimmy Fortin <jimmy.fortin@corp.ovh.com>

Previously on Windows `yarn karma` and `yarn karma:watch` could not be run because `$(npm bin)` could not be found, so karma wasn't run. 

I replaced `$(npm bin)` by `node_modules/karma/bin` and it seems to work find on Windows and Mac but I didn't tested it on Linux.