### PR TITLE
fix(*): fix removeAttr parameter for jqLite

### DIFF
--- a/packages/oui-action-menu/src/action-menu-item.controller.js
+++ b/packages/oui-action-menu/src/action-menu-item.controller.js
@@ -24,19 +24,19 @@ export default class {
     }
 
     $postLink () {
-        this.$timeout(() => {
-            let compiled;
+        let compiled;
 
-            this.$element.removeAttr("aria-label");
+        this.$timeout(() =>
+            this.$element.removeAttr("aria-label")
+        );
 
-            if (this.$attrs.onClick) {
-                compiled = this.$compile(buttomTemplate);
-            } else {
-                compiled = this.$compile(linkTemplate);
-            }
+        if (this.$attrs.onClick) {
+            compiled = this.$compile(buttomTemplate);
+        } else {
+            compiled = this.$compile(linkTemplate);
+        }
 
-            this.$element.empty();
-            this.$element.append(compiled(this.$scope));
-        });
+        this.$element.empty();
+        this.$element.append(compiled(this.$scope));
     }
 }

--- a/packages/oui-action-menu/src/action-menu-item.controller.js
+++ b/packages/oui-action-menu/src/action-menu-item.controller.js
@@ -26,6 +26,8 @@ export default class {
     $postLink () {
         let compiled;
 
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element.removeAttr("aria-label")
         );

--- a/packages/oui-action-menu/src/action-menu-item.controller.js
+++ b/packages/oui-action-menu/src/action-menu-item.controller.js
@@ -3,13 +3,14 @@ import buttomTemplate from "./action-menu-item-button.html";
 import linkTemplate from "./action-menu-item-link.html";
 
 export default class {
-    constructor ($attrs, $compile, $element, $scope) {
+    constructor ($attrs, $compile, $element, $scope, $timeout) {
         "ngInject";
 
         this.$attrs = $attrs;
         this.$compile = $compile;
         this.$element = $element;
         this.$scope = $scope;
+        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -23,17 +24,19 @@ export default class {
     }
 
     $postLink () {
-        let compiled;
+        this.$timeout(() => {
+            let compiled;
 
-        this.$element.removeAttr("aria-label");
+            this.$element.removeAttr("aria-label");
 
-        if (this.$attrs.onClick) {
-            compiled = this.$compile(buttomTemplate);
-        } else {
-            compiled = this.$compile(linkTemplate);
-        }
+            if (this.$attrs.onClick) {
+                compiled = this.$compile(buttomTemplate);
+            } else {
+                compiled = this.$compile(linkTemplate);
+            }
 
-        this.$element.empty();
-        this.$element.append(compiled(this.$scope));
+            this.$element.empty();
+            this.$element.append(compiled(this.$scope));
+        });
     }
 }

--- a/packages/oui-action-menu/src/action-menu.controller.js
+++ b/packages/oui-action-menu/src/action-menu.controller.js
@@ -17,6 +17,8 @@ export default class {
     }
 
     $postLink () {
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("align")

--- a/packages/oui-action-menu/src/action-menu.controller.js
+++ b/packages/oui-action-menu/src/action-menu.controller.js
@@ -3,11 +3,12 @@ import { addBooleanParameter } from "@oui-angular/common/component-utils";
 const baseClass = "oui-action-menu";
 
 export default class {
-    constructor ($attrs, $element) {
+    constructor ($attrs, $element, $timeout) {
         "ngInject";
 
         this.$attrs = $attrs;
         this.$element = $element;
+        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -16,8 +17,10 @@ export default class {
     }
 
     $postLink () {
-        this.$element
-            .removeAttr("align")
-            .removeAttr("aria-label");
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("align")
+                .removeAttr("aria-label")
+        );
     }
 }

--- a/packages/oui-action-menu/src/action-menu.controller.js
+++ b/packages/oui-action-menu/src/action-menu.controller.js
@@ -16,6 +16,8 @@ export default class {
     }
 
     $postLink () {
-        this.$element.removeAttr("align aria-label");
+        this.$element
+            .removeAttr("align")
+            .removeAttr("aria-label");
     }
 }

--- a/packages/oui-back-button/src/back-button.controller.js
+++ b/packages/oui-back-button/src/back-button.controller.js
@@ -1,18 +1,21 @@
 export default class {
-    constructor ($element, $window) {
+    constructor ($element, $timeout, $window) {
         "ngInject";
 
         this.$element = $element;
+        this.$timeout = $timeout;
         this.$window = $window;
     }
 
     $postLink () {
         // Remove ID and Name to avoid duplicate
         // And accessibility attributes on the root component
-        this.$element
-            .removeAttr("aria-label")
-            .removeAttr("id")
-            .removeAttr("name");
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("aria-label")
+                .removeAttr("id")
+                .removeAttr("name")
+        );
     }
 
     onBtnClick () {

--- a/packages/oui-back-button/src/back-button.controller.js
+++ b/packages/oui-back-button/src/back-button.controller.js
@@ -8,8 +8,8 @@ export default class {
     }
 
     $postLink () {
-        // Remove ID and Name to avoid duplicate
-        // And accessibility attributes on the root component
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("aria-label")

--- a/packages/oui-back-button/src/back-button.controller.js
+++ b/packages/oui-back-button/src/back-button.controller.js
@@ -9,9 +9,10 @@ export default class {
     $postLink () {
         // Remove ID and Name to avoid duplicate
         // And accessibility attributes on the root component
-        this.$element.removeAttr("aria-label");
-        this.$element.removeAttr("id");
-        this.$element.removeAttr("name");
+        this.$element
+            .removeAttr("aria-label")
+            .removeAttr("id")
+            .removeAttr("name");
     }
 
     onBtnClick () {

--- a/packages/oui-back-button/src/index.spec.js
+++ b/packages/oui-back-button/src/index.spec.js
@@ -1,13 +1,15 @@
 describe("ouiBackButton", () => {
     let $rootScope;
     let $compile;
+    let $timeout;
     let $window;
 
     beforeEach(angular.mock.module("oui.back-button"));
 
-    beforeEach(inject((_$rootScope_, _$compile_, _$window_) => {
+    beforeEach(inject((_$rootScope_, _$compile_, _$timeout_, _$window_) => {
         $rootScope = _$rootScope_;
         $compile = _$compile_;
+        $timeout = _$timeout_;
         $window = _$window_;
         spyOn($window.history, "back");
     }));
@@ -30,6 +32,9 @@ describe("ouiBackButton", () => {
 
         it("should have and id and name attribute, and remove it from root component", () => {
             const element = compile('<oui-back-button id="foo" name="bar"></oui-back-button>');
+
+            $timeout.flush();
+
             expect(element.find("button").attr("id")).toBe("foo");
             expect(element.find("button").attr("name")).toBe("bar");
             expect(element.attr("id")).toBeUndefined();
@@ -38,6 +43,9 @@ describe("ouiBackButton", () => {
 
         it("should have and aria-label attribute, and remove it from root component", () => {
             const element = compile('<oui-back-button aria-label="foo"></oui-back-button>');
+
+            $timeout.flush();
+
             expect(element.find("button").attr("aria-label")).toBe("foo");
             expect(element.attr("aria-label")).toBeUndefined();
         });

--- a/packages/oui-button/src/button.controller.js
+++ b/packages/oui-button/src/button.controller.js
@@ -25,9 +25,8 @@ export default class {
     }
 
     $postLink () {
-        // Remove ID and Name to avoid duplicate
-        // And accessibility attributes on the root component
-
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("aria-label")

--- a/packages/oui-button/src/button.controller.js
+++ b/packages/oui-button/src/button.controller.js
@@ -26,8 +26,9 @@ export default class {
     $postLink () {
         // Remove ID and Name to avoid duplicate
         // And accessibility attributes on the root component
-        this.$element.removeAttr("aria-label");
-        this.$element.removeAttr("id");
-        this.$element.removeAttr("name");
+        this.$element
+            .removeAttr("aria-label")
+            .removeAttr("id")
+            .removeAttr("name");
     }
 }

--- a/packages/oui-button/src/button.controller.js
+++ b/packages/oui-button/src/button.controller.js
@@ -1,9 +1,10 @@
 export default class {
-    constructor ($attrs, $element) {
+    constructor ($attrs, $element, $timeout) {
         "ngInject";
 
         this.$attrs = $attrs;
         this.$element = $element;
+        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -26,9 +27,12 @@ export default class {
     $postLink () {
         // Remove ID and Name to avoid duplicate
         // And accessibility attributes on the root component
-        this.$element
-            .removeAttr("aria-label")
-            .removeAttr("id")
-            .removeAttr("name");
+
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("aria-label")
+                .removeAttr("id")
+                .removeAttr("name")
+        );
     }
 }

--- a/packages/oui-button/src/index.spec.js
+++ b/packages/oui-button/src/index.spec.js
@@ -1,12 +1,14 @@
 describe("ouiButton", () => {
     let $componentController;
+    let $timeout;
     let testUtils;
 
     beforeEach(angular.mock.module("oui.button"));
     beforeEach(angular.mock.module("oui.test-utils"));
 
-    beforeEach(inject((_$componentController_, _TestUtils_) => {
+    beforeEach(inject((_$componentController_, _$timeout_, _TestUtils_) => {
         $componentController = _$componentController_;
+        $timeout = _$timeout_;
         testUtils = _TestUtils_;
     }));
 
@@ -35,6 +37,8 @@ describe("ouiButton", () => {
             const component = testUtils.compileTemplate('<oui-button id="foo" name="bar"></oui-button>');
             const button = component.find("button").eq(0);
 
+            $timeout.flush();
+
             expect(component.attr("id")).toBe(undefined);
             expect(button.attr("id")).toBe("foo");
 
@@ -44,6 +48,8 @@ describe("ouiButton", () => {
 
         it("should have an attribute aria-label on the button, and removed on the root component", () => {
             const component = testUtils.compileTemplate('<oui-button aria-label="foo"></oui-button>');
+
+            $timeout.flush();
 
             expect(component.attr("aria-label")).toBe(undefined);
             expect(component.find("button").eq(0).attr("aria-label")).toBe("foo");

--- a/packages/oui-checkbox/src/checkbox.controller.js
+++ b/packages/oui-checkbox/src/checkbox.controller.js
@@ -8,7 +8,9 @@ export default class {
     }
 
     $postLink () {
-        this.$element.removeAttr("id name");
+        this.$element
+            .removeAttr("id")
+            .removeAttr("name");
 
         this.checkboxElement = this.$element.find("input");
 

--- a/packages/oui-checkbox/src/checkbox.controller.js
+++ b/packages/oui-checkbox/src/checkbox.controller.js
@@ -9,6 +9,8 @@ export default class {
     }
 
     $postLink () {
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("id")

--- a/packages/oui-checkbox/src/checkbox.controller.js
+++ b/packages/oui-checkbox/src/checkbox.controller.js
@@ -1,16 +1,19 @@
 export default class {
-    constructor ($scope, $element, $attrs) {
+    constructor ($scope, $element, $attrs, $timeout) {
         "ngInject";
 
         this.$scope = $scope;
         this.$element = $element;
         this.$attrs = $attrs;
+        this.$timeout = $timeout;
     }
 
     $postLink () {
-        this.$element
-            .removeAttr("id")
-            .removeAttr("name");
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("id")
+                .removeAttr("name")
+        );
 
         this.checkboxElement = this.$element.find("input");
 

--- a/packages/oui-numeric/src/numeric.controller.js
+++ b/packages/oui-numeric/src/numeric.controller.js
@@ -5,18 +5,21 @@ const MIN_VALUE = 0;
 const MAX_VALUE = 99999;
 
 export default class {
-    constructor ($attrs, $element, $log) {
+    constructor ($attrs, $element, $log, $timeout) {
         "ngInject";
 
         this.$attrs = $attrs;
         this.$element = $element;
         this.$log = $log;
+        this.$timeout = $timeout;
     }
 
     $postLink () {
-        this.$element
-            .removeAttr("id")
-            .removeAttr("name");
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("id")
+                .removeAttr("name")
+        );
     }
 
     $onInit () {

--- a/packages/oui-numeric/src/numeric.controller.js
+++ b/packages/oui-numeric/src/numeric.controller.js
@@ -15,6 +15,8 @@ export default class {
     }
 
     $postLink () {
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("id")

--- a/packages/oui-numeric/src/numeric.controller.js
+++ b/packages/oui-numeric/src/numeric.controller.js
@@ -14,7 +14,9 @@ export default class {
     }
 
     $postLink () {
-        this.$element.removeAttr("id name");
+        this.$element
+            .removeAttr("id")
+            .removeAttr("name");
     }
 
     $onInit () {

--- a/packages/oui-radio/src/radio.controller.js
+++ b/packages/oui-radio/src/radio.controller.js
@@ -11,6 +11,8 @@ export default class {
     }
 
     $postLink () {
+        // Sometimes the digest cycle is done before dom manipulation,
+        // So we use $timeout to force the $apply
         this.$timeout(() =>
             this.$element
                 .removeAttr("id")

--- a/packages/oui-radio/src/radio.controller.js
+++ b/packages/oui-radio/src/radio.controller.js
@@ -10,7 +10,9 @@ export default class {
     }
 
     $postLink () {
-        this.$element.removeAttr("id name");
+        this.$element
+            .removeAttr("id")
+            .removeAttr("name");
     }
 
     $onInit () {

--- a/packages/oui-radio/src/radio.controller.js
+++ b/packages/oui-radio/src/radio.controller.js
@@ -1,18 +1,21 @@
 import { addBooleanParameter } from "@oui-angular/common/component-utils";
 
 export default class {
-    constructor ($scope, $element, $attrs) {
+    constructor ($scope, $element, $attrs, $timeout) {
         "ngInject";
 
         this.$scope = $scope;
         this.$element = $element;
         this.$attrs = $attrs;
+        this.$timeout = $timeout;
     }
 
     $postLink () {
-        this.$element
-            .removeAttr("id")
-            .removeAttr("name");
+        this.$timeout(() =>
+            this.$element
+                .removeAttr("id")
+                .removeAttr("name")
+        );
     }
 
     $onInit () {

--- a/packages/oui-tooltip/src/tooltip.controller.js
+++ b/packages/oui-tooltip/src/tooltip.controller.js
@@ -2,13 +2,12 @@ import Popper from "popper.js";
 import template from "./tooltip.html";
 
 export default class {
-    constructor ($compile, $element, $scope, $timeout) {
+    constructor ($compile, $element, $scope) {
         "ngInject";
 
         this.$compile = $compile;
         this.$element = $element;
         this.$scope = $scope;
-        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -19,27 +18,25 @@ export default class {
     }
 
     $postLink () {
-        this.$timeout(() => {
-            // Add an attribute 'aria-label' if undefined
-            if (!this.$element.attr("aria-label")) {
-                this.$element.attr("aria-label", this.text);
-            }
+    // Add an attribute 'aria-label' if undefined
+        if (!this.$element.attr("aria-label")) {
+            this.$element.attr("aria-label", this.text);
+        }
 
-            // Create a new scope to compile the tooltip next to the trigger
-            const tooltipScope = angular.extend(this.$scope.$new(true), { $ctrl: this });
-            const tooltipTemplate = this.$compile(template)(tooltipScope);
+        // Create a new scope to compile the tooltip next to the trigger
+        const tooltipScope = angular.extend(this.$scope.$new(true), { $ctrl: this });
+        const tooltipTemplate = this.$compile(template)(tooltipScope);
 
-            this.$element
+        this.$element
 
-            // Add classname for 'focus' and 'hover' CSS events
-                .addClass("oui-tooltip__trigger")
+        // Add classname for 'focus' and 'hover' CSS events
+            .addClass("oui-tooltip__trigger")
 
-            // one time bind to create the popper helper
-                .one("focus mouseenter", () => this.createPopper())
+        // one time bind to create the popper helper
+            .one("focus mouseenter", () => this.createPopper())
 
-            // Add compiled template after $element
-                .after(tooltipTemplate);
-        });
+        // Add compiled template after $element
+            .after(tooltipTemplate);
     }
 
     createPopper () {

--- a/packages/oui-tooltip/src/tooltip.controller.js
+++ b/packages/oui-tooltip/src/tooltip.controller.js
@@ -2,12 +2,13 @@ import Popper from "popper.js";
 import template from "./tooltip.html";
 
 export default class {
-    constructor ($compile, $element, $scope) {
+    constructor ($compile, $element, $scope, $timeout) {
         "ngInject";
 
         this.$compile = $compile;
         this.$element = $element;
         this.$scope = $scope;
+        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -18,25 +19,27 @@ export default class {
     }
 
     $postLink () {
-    // Add an attribute 'aria-label' if undefined
-        if (!this.$element.attr("aria-label")) {
-            this.$element.attr("aria-label", this.text);
-        }
+        this.$timeout(() => {
+            // Add an attribute 'aria-label' if undefined
+            if (!this.$element.attr("aria-label")) {
+                this.$element.attr("aria-label", this.text);
+            }
 
-        // Create a new scope to compile the tooltip next to the trigger
-        const tooltipScope = angular.extend(this.$scope.$new(true), { $ctrl: this });
-        const tooltipTemplate = this.$compile(template)(tooltipScope);
+            // Create a new scope to compile the tooltip next to the trigger
+            const tooltipScope = angular.extend(this.$scope.$new(true), { $ctrl: this });
+            const tooltipTemplate = this.$compile(template)(tooltipScope);
 
-        this.$element
+            this.$element
 
-        // Add classname for 'focus' and 'hover' CSS events
-            .addClass("oui-tooltip__trigger")
+            // Add classname for 'focus' and 'hover' CSS events
+                .addClass("oui-tooltip__trigger")
 
-        // one time bind to create the popper helper
-            .one("focus mouseenter", () => this.createPopper())
+            // one time bind to create the popper helper
+                .one("focus mouseenter", () => this.createPopper())
 
-        // Add compiled template after $element
-            .after(tooltipTemplate);
+            // Add compiled template after $element
+                .after(tooltipTemplate);
+        });
     }
 
     createPopper () {


### PR DESCRIPTION
Unlike what was done for fixing removeAttr bug from what jQuery documentation said (https://github.com/ovh-ux/ovh-ui-angular/pull/50), jqLite doesn't support multiple attributes: https://docs.angularjs.org/api/ng/function/angular.element

So we have to call `.removeAttr()` for each attributes.