### PR TITLE
fix(datagrid): avoid sorting if property attribute is not set in oui-column

### DIFF
--- a/packages/oui-datagrid/src/datagrid-column-builder.service.js
+++ b/packages/oui-datagrid/src/datagrid-column-builder.service.js
@@ -25,13 +25,13 @@ export default class DatagridColumnBuilder {
 
                 column.name = propertyValue;
                 column.getValue = this.$parse(propertyValue);
-            }
 
-            if (hasAttribute(columnElement, "sortable")) {
-                const sortableValue = getAttribute(columnElement, "sortable");
-
-                column.sortable = sortableValue !== undefined;
-                Object.assign(currentSorting, DatagridColumnBuilder.defineDefaultSorting(column, sortableValue));
+                // A column can be sorted only if it has a "property" attribute.
+                if (hasAttribute(columnElement, "sortable")) {
+                    const sortableValue = getAttribute(columnElement, "sortable");
+                    column.sortable = sortableValue !== undefined;
+                    Object.assign(currentSorting, DatagridColumnBuilder.defineDefaultSorting(column, sortableValue));
+                }
             }
 
             copyValueProperties.forEach(propertyName => {


### PR DESCRIPTION
Signed-off-by: Kevin Manson kevin.manson@corp.ovh.com