### PR TITLE
feat(navbar): add a toggler-links attribute

### DIFF
--- a/packages/oui-navbar/README.md
+++ b/packages/oui-navbar/README.md
@@ -22,7 +22,8 @@
     brand="$ctrl.brand"
     active-link="lorem"
     main-links="$ctrl.mainLinks"
-    aside-links="$ctrl.asideLinks">
+    aside-links="$ctrl.asideLinks"
+    toggler-links="$ctrl.togglerLinks">
 </oui-navbar>
 </div>
 ```
@@ -37,6 +38,7 @@ Note: All children menus have `.oui-navbar-menu_fixed`. The component is intende
 | active-link   | string    | @?        | true                |                      |           | current active-link of the navbar                                             |
 | main-links    | array     | <?        | true                | _see example below_  |           | array of objects for the items on the left and the toggler (for responsive)   |
 | aside-links   | array     | <?        | true                | _see example below_  |           | array of objects for the items on the right                                   |
+| toggler-links | array     | <?        | true                | _see example below_  |           | array of objects for the responsive menu                                      |
 | fixed         | boolean   | <?        | true                |                      | false     | set the navbar in fixed mode                                                  |
 
 ### Properties of attribute `brand`
@@ -161,6 +163,8 @@ The menu item will be set as a `<button>`.
 }
 ```
 
+Note: Root links can have `url` and `subLinks`. `subLinks` will only be used for the responsive menu.
+
 ### Properties of attribute `main-links`
 
 This property is only available for root links of `main-links`.
@@ -183,8 +187,6 @@ This property is only available for root links of `main-links`.
     }]
 }]
 ```
-
-Note: Root links can have `url` and `subLinks`. `subLinks` will only be used for the responsive menu.
 
 ### Properties of attribute `aside-links`
 

--- a/packages/oui-navbar/src/index.spec.js
+++ b/packages/oui-navbar/src/index.spec.js
@@ -150,8 +150,8 @@ describe("ouiNavbar", () => {
             let responsiveMenu;
 
             beforeEach(() => {
-                component = testUtils.compileTemplate('<oui-navbar main-links="$ctrl.mainLinks"></oui-navbar>', {
-                    mainLinks: data
+                component = testUtils.compileTemplate('<oui-navbar toggler-links="$ctrl.togglerLinks"></oui-navbar>', {
+                    togglerLinks: data
                 });
 
                 toggler = angular.element(component[0].querySelector(".oui-navbar-toggler"));

--- a/packages/oui-navbar/src/navbar.component.js
+++ b/packages/oui-navbar/src/navbar.component.js
@@ -7,6 +7,7 @@ export default {
         activeLink: "@?",
         mainLinks: "<?",
         asideLinks: "<?",
+        togglerLinks: "<?",
 
         fixed: "<?"
     },

--- a/packages/oui-navbar/src/navbar.controller.js
+++ b/packages/oui-navbar/src/navbar.controller.js
@@ -17,9 +17,28 @@ export default class {
         this.navigation = this.navbarService.toggleMenu(state, isInternalNav);
     }
 
+    updateLinks () {
+        // If no togglerLinks attribute, we use the value of mainLinks
+        if (!angular.isDefined(this.$attrs.togglerLinks) && angular.isDefined(this.$attrs.mainLinks)) {
+            this.togglerLinks = this.mainLinks;
+            this.togglerLoaded = true;
+        }
+    }
+
     $onInit () {
+        this.updateLinks();
+
         // Support presence of attribute 'fixed'
         addBooleanParameter(this, "fixed");
+    }
+
+    $onChanges (changes) {
+        this.updateLinks();
+
+        // Get togglerLinks changes for the loader
+        if (changes.togglerLinks) {
+            this.togglerLoaded = !!changes.togglerLinks.currentValue;
+        }
     }
 
     $postLink () {

--- a/packages/oui-navbar/src/navbar.html
+++ b/packages/oui-navbar/src/navbar.html
@@ -1,7 +1,7 @@
 <!-- Toggler -->
 <button class="oui-navbar-toggler" type="button"
     aria-haspopup="true" aria-expanded="{{!!$ctrl.navigation['toggler']}}"
-    ng-if="::$ctrl.mainLinks"
+    ng-if="::$ctrl.togglerLinks"
     ng-click="$ctrl.toggleMenu('toggler')"
     oui-navbar-group="toggler">
     <span class="oui-navbar-toggler__hamburger">
@@ -11,12 +11,15 @@
         <span></span>
     </span>
 </button>
+<span class="oui-navbar-toggler" ng-if="!$ctrl.togglerLoaded">
+    <oui-spinner size="s"></oui-spinner>
+</span>
 <oui-navbar-menu
-    ng-if="::$ctrl.mainLinks"
+    ng-if="::$ctrl.togglerLinks"
     class="oui-navbar-menu_fixed oui-navbar-menu_toggle"
     children-class="oui-navbar-menu_fixed"
     name="toggler"
-    links="::$ctrl.mainLinks"
+    links="::$ctrl.togglerLinks"
     navigation="$ctrl.navigation"
     expanded="$ctrl.navigation['toggler']">
 </oui-navbar-menu>


### PR DESCRIPTION
UU-714

Add an attribute dedicated for the responsive menu.
In this way, we can faster displaying the navbar.

Linked to https://github.com/ovh-ux/ovh-ui-kit-documentation/pull/57