### PR TITLE
fix(select): make match optional (handle string list)

### DIFF
--- a/packages/oui-select/README.md
+++ b/packages/oui-select/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-### Basic
+### Basic (Object array)
 
 ```html:preview
 <oui-select name="country"
@@ -16,6 +16,18 @@
     match="name"
     data-align="start">
     <span ng-bind="$item.name"></span>
+</oui-select>
+```
+
+### Basic (String array)
+
+```html:preview
+<oui-select name="country"
+    model="$ctrl.country"
+    items="['a', 'b', 'c']"
+    required
+    data-align="start">
+    <span ng-bind="$item"></span>
 </oui-select>
 ```
 
@@ -66,7 +78,7 @@
 | `required`        | boolean                 | <?      |                  | `true`, `false`           | `false`             | define if the field is required                   |
 | `disabled`        | boolean                 | <?      |                  | `true`, `false`           | `false`             | define if the field is disabled                   |
 | `group-by`        | function                | <?      |                  |                           |                     | function taking an item as parameter and returning the group name as as string                   |
-| `match`           | string                  | @       |                  |                           |                     | property of item to show as selected item         |
+| `match`           | string                  | @?      |                  |                           |                     | property of item to show as selected item         |
 | `data-align`      | string                  | @?      |                  | `start`, `end`            | `start`             | dropdown alignment                                |
 | `on-blur`         | string                  | &?      |                  |                           |                     | called focus is lost                              |
 | `on-focus`        | string                  | &?      |                  |                           |                     | called on focus                                   |

--- a/packages/oui-select/src/index.spec.js
+++ b/packages/oui-select/src/index.spec.js
@@ -146,7 +146,7 @@ describe("ouiSelect", () => {
         });
 
         describe("Not grouped", () => {
-            it("should display all the choices", () => {
+            it("should display all the choices (objectArray)", () => {
                 const element = TestUtils.compileTemplate(`
                     <oui-select name="country"
                         model="$ctrl.country"
@@ -163,6 +163,25 @@ describe("ouiSelect", () => {
                 expect(getDropdownItems(element).length).toEqual(data.length);
                 expect(angular.element(getDropdownItem(element, 0)).text()).toContain(data[0].name);
                 expect(angular.element(getDropdownItem(element, data.length - 1)).text()).toContain(data[data.length - 1].name);
+                expect(getItemsGroups(element).length).toEqual(1);
+            });
+
+            it("should display all the choices (stringArray)", () => {
+                const stringArray = ["a", "b", "c"];
+                const element = TestUtils.compileTemplate(`
+                    <oui-select name="country"
+                        data-title="Select a country"
+                        model="$ctrl.country"
+                        items="$ctrl.array"
+                        data-align="start">
+                        <span ng-bind="$item"></span>
+                    </oui-select>`, {
+                    array: stringArray
+                });
+
+                expect(getDropdownItems(element).length).toEqual(stringArray.length);
+                expect(angular.element(getDropdownItem(element, 0)).text()).toContain(stringArray[0]);
+                expect(angular.element(getDropdownItem(element, stringArray.length - 1)).text()).toContain(stringArray[stringArray.length - 1]);
                 expect(getItemsGroups(element).length).toEqual(1);
             });
         });

--- a/packages/oui-select/src/select.directive.js
+++ b/packages/oui-select/src/select.directive.js
@@ -17,7 +17,7 @@ export default () => ({
         title: "@?",
         placeholder: "@?",
         items: "<",
-        match: "@",
+        match: "@?",
         groupBy: "<?",
         align: "@?",
         onBlur: "&?",
@@ -34,7 +34,12 @@ export default () => ({
             choicesElement.attr("group-by", "$ctrl.groupBy");
         }
 
-        matchElement.html(`{{$select.selected.${$attrs.match}}}`);
+        if ($attrs.match) {
+            matchElement.html(`{{$select.selected.${$attrs.match}}}`);
+        } else {
+            matchElement.html("{{$select.selected}}");
+        }
+
 
         const htmlContent = $template[0].outerHTML;
         $element.empty();


### PR DESCRIPTION
In case of string list instead of objects list passing to your item. You won't be able to match object attribute. So, to handle this case match attribute has been turned to optional.

http://angular_fix_oui_select.ui-kit.ovh/#!/oui-angular/select