### PR TITLE
docs:standardize documentation

### DIFF
--- a/packages/oui-back-button/README.md
+++ b/packages/oui-back-button/README.md
@@ -4,20 +4,6 @@
 
 ## Usage
 
-```html
-<oui-back-button
-    id="..."
-    name="..."
-    aria-label="..."
-    title="..."
-    on-click="...">
-</oui-back-button>
-```
-
-If ```on-click``` is not specified, the default action on user click will be angular's ```$window.history.back()```.
-
-## Examples
-
 ### Default
 
 ```html:preview

--- a/packages/oui-button/README.md
+++ b/packages/oui-button/README.md
@@ -4,36 +4,6 @@
 
 ## Usage
 
-```html
-<oui-button
-  text="..."
-  variant="primary|secondary|link"
-  variant-nav="previous|next"
-  type="submit|button|reset"
-  id="..."
-  name="..."
-  disabled|disabled="true|false"
-  aria-label="..."
-  on-click="..."
-></oui-button>
-```
-
-## API
-
-| Attribute     | Type     | Binding | One-time Binding | Values                 | Default   | Description                      |
-| ----          | ----     | ----    | ----             | ----                   | ----      | ----                             |
-| text          | string   | @       | true             |                        |           | button text                      |
-| id            | string   | @?      | true             |                        |           | id attribute of the button       |
-| name          | string   | @?      | true             |                        |           | name attribute of the button     |
-| type          | string   | @?      | true             | submit,button,reset    | button    | type attribute of the button     |
-| variant       | string   | @?      | true             | primary,secondary,link | secondary | modifier for button              |
-| variant-nav   | string   | @?      | true             | next,previous          |           | nav modifier for button          |
-| aria-label    | string   | @?      | true             |                        |           | accessibility label              |
-| disabled      | boolean  | <?      |                  |                        | false     | disabled flag                    |
-| on-click      | function | &?      |                  |                        |           | click handler                    |
-
-## Examples
-
 ### Default
 
 ```html:preview
@@ -77,3 +47,17 @@
 ```
 
 - `aria-label` add an attribute `aria-label` on the button.
+
+## API
+
+| Attribute     | Type     | Binding | One-time Binding | Values                 | Default   | Description                      |
+| ----          | ----     | ----    | ----             | ----                   | ----      | ----                             |
+| text          | string   | @       | true             |                        |           | button text                      |
+| id            | string   | @?      | true             |                        |           | id attribute of the button       |
+| name          | string   | @?      | true             |                        |           | name attribute of the button     |
+| type          | string   | @?      | true             | submit,button,reset    | button    | type attribute of the button     |
+| variant       | string   | @?      | true             | primary,secondary,link | secondary | modifier for button              |
+| variant-nav   | string   | @?      | true             | next,previous          |           | nav modifier for button          |
+| aria-label    | string   | @?      | true             |                        |           | accessibility label              |
+| disabled      | boolean  | <?      |                  |                        | false     | disabled flag                    |
+| on-click      | function | &?      |                  |                        |           | click handler   

--- a/packages/oui-checkbox/README.md
+++ b/packages/oui-checkbox/README.md
@@ -4,33 +4,6 @@
 
 ## Usage
 
-```html
-<oui-checkbox
-  text="..."
-  description="..."
-  id="..."
-  name="..."
-  disabled="..."
-  model="..."
-  on-change="..."
-></oui-checkbox>
-```
-
-## API
-
-| Attribute     | Type                    | Binding | One-time Binding | Values                   | Default | Description
-| ----          | ----                    | ----    | ----             | ----                     | ----    | ----
-| text          | string                  | @       |                  |                          |         | checkbox text
-| description   | string                  | @?      |                  |                          |         | description text
-| id            | string                  | @?      | `true`           |                          |         | id attribute of the checkbox
-| name          | string                  | @?      | `true`           |                          |         | name attribute of the checkbox
-| disabled      | boolean                 | <?      |                  |                          | false   | disabled flag
-| model         | nullable&lt;boolean&gt; | =?      |                  | `true`, `false`, `null`  |         | current value of the checkbox and null is considered as `indeterminate`
-| required      | boolean                 | <?      |                  |                          | false   | `true` if the checkbox should be checked
-| on-change     | function                | &?      |                  |                          |         | handler triggered when value has changed
-
-## Examples
-
 ### Unchecked
 
 ```html:preview
@@ -94,3 +67,15 @@
 
 Needs to be done.
 
+## API
+
+| Attribute     | Type                    | Binding | One-time Binding | Values                   | Default | Description
+| ----          | ----                    | ----    | ----             | ----                     | ----    | ----
+| text          | string                  | @       |                  |                          |         | checkbox text
+| description   | string                  | @?      |                  |                          |         | description text
+| id            | string                  | @?      | `true`           |                          |         | id attribute of the checkbox
+| name          | string                  | @?      | `true`           |                          |         | name attribute of the checkbox
+| disabled      | boolean                 | <?      |                  |                          | false   | disabled flag
+| model         | nullable&lt;boolean&gt; | =?      |                  | `true`, `false`, `null`  |         | current value of the checkbox and null is considered as `indeterminate`
+| required      | boolean                 | <?      |                  |                          | false   | `true` if the checkbox should be checked
+| on-change     | function                | &?      |                  |                          |         | handler triggered when value has changed

--- a/packages/oui-datagrid/README.md
+++ b/packages/oui-datagrid/README.md
@@ -4,22 +4,6 @@
 
 ## Usage
 
-```html
-<oui-datagrid
-  page-size="..."
-  rows="..."
-  rows-loader="..."
-  row-loader="...">
-  <oui-column
-    title="..."
-    property="..."
-    sortable="...">
-  </oui-column>
-</oui-datagrid>
-```
-
-## Examples
-
 ### Local data
 
 ```html:preview

--- a/packages/oui-dropdown/README.md
+++ b/packages/oui-dropdown/README.md
@@ -2,7 +2,9 @@
 
 <component-status cx-design="complete" ux="rc"></component-status>
 
-## Centered by default with default trigger
+## Usage
+
+### Centered by default with default trigger
 
 ```html:preview
 <div style="text-align: center" class="oui-doc-preview-only-keep-children">
@@ -15,7 +17,7 @@
 </div>
 ```
 
-## Alignment
+### Alignment
 
 ```html:preview
 <div class="oui-doc-preview-only-keep-children">
@@ -40,7 +42,7 @@
 </div>
 ```
 
-## With arrow
+### With arrow
 
 ```html:preview
 <div class="oui-doc-preview-only-keep-children">

--- a/packages/oui-form-actions/README.md
+++ b/packages/oui-form-actions/README.md
@@ -4,15 +4,6 @@
 
 ## Usage
 
-```html
-<oui-form-actions
-  on-submit="$ctrl.submit()"
-  on-cancel="$ctrl.cancel()">
-</oui-form-actions>
-```
-
-## Examples
-
 ### Default
 
 ```html:preview

--- a/packages/oui-message/README.md
+++ b/packages/oui-message/README.md
@@ -4,16 +4,6 @@
 
 ## Usage
 
-```html
-<oui-message
-    type="info|success|warning|error"
-    on-dismissed="..."
-    aria-close-button-label="...">
-</oui-message>
-```
-
-## Examples
-
 ### Information
 
 ```html:preview

--- a/packages/oui-navbar/README.md
+++ b/packages/oui-navbar/README.md
@@ -4,18 +4,6 @@
 
 ## Usage
 
-```html
-<oui-navbar
-    brand="..."
-    active-link="..."
-    main-links="..."
-    aside-links="..."
-    fixed|fixed="true|false"
-></oui-navbar>
-```
-
-### Example
-
 ```html:preview
 <div class="oui-doc-preview-only-keep-children" style="margin-bottom: 15px;">
 <oui-navbar

--- a/packages/oui-numeric/README.md
+++ b/packages/oui-numeric/README.md
@@ -4,20 +4,6 @@
 
 ## Usage
 
-```html
-<oui-numeric
-  id="..."
-  name="..."
-  model="..."
-  min="..."
-  max="..."
-  disabled|disabled="true|false"
-  on-change="...">
-</oui-numeric>
-```
-
-## Examples
-
 ### Default
 
 ```html:preview

--- a/packages/oui-pagination/README.md
+++ b/packages/oui-pagination/README.md
@@ -2,8 +2,6 @@
 
 <component-status cx-design="complete" ux="rc"></component-status>
 
-
-
 ## Usage
 
 ### A few pages

--- a/packages/oui-radio-group/README.md
+++ b/packages/oui-radio-group/README.md
@@ -4,18 +4,6 @@
 
 ## Usage
 
-```html
-<oui-radio-group
-  model="..."
-  name="...",
-  on-change="...">
-    <oui-radio/>
-    <oui-radio/>
-</oui-radio-group>
-```
-
-## Examples
-
 ### Default
 
 ```html:preview

--- a/packages/oui-radio/README.md
+++ b/packages/oui-radio/README.md
@@ -4,21 +4,6 @@
 
 ## Usage
 
-```html
-<oui-radio
-  text="..."
-  description="..."
-  id="..."
-  name="..."
-  disabled="..."
-  model="..."
-  value="..."
-  on-change="..."
-></oui-radio>
-```
-
-## Examples
-
 ### Basic
 
 ```html:preview

--- a/packages/oui-search/README.md
+++ b/packages/oui-search/README.md
@@ -4,22 +4,6 @@
 
 ## Usage
 
-```html
-<oui-search
-    model="..."
-    id="..."
-    name="..."
-    placeholder="..."
-    aria-label="..."
-    disabled|disabled="true|false"
-    on-change="..."
-    on-reset="..."
-    on-submit="...">
-</oui-search>
-```
-
-## Examples
-
 ### Basic
 
 ```html:preview

--- a/packages/oui-spinner/README.md
+++ b/packages/oui-spinner/README.md
@@ -4,12 +4,6 @@
 
 ## Usage
 
-```html
-<oui-spinner size="s|m|l"></oui-spinner>
-```
-
-## Examples
-
 ### Small
 ```html:preview
 <oui-spinner size="s"></oui-spinner>

--- a/packages/oui-tooltip/README.md
+++ b/packages/oui-tooltip/README.md
@@ -4,26 +4,6 @@
 
 ## Usage
 
-```html
-<span
-  oui-tooltip="..."
-  oui-tooltip-placement="top|top-start|top-end|bottom|bottom-start|bottom-end"
->...</span>
-```
-
-## API
-
-| Attribute             | Type   | Binding | One-time Binding | Values                                               | Default   | Description       |
-| ----                  | ----   | ----    | ----             | ----                                                 | ----      | ----              |
-| oui-tooltip           | string | @       | true             |                                                      |           | tooltip text      |
-| oui-tooltip-placement | string | @?      | true             | top,top-start,top-end,bottom,bottom-start,bottom-end | top       | tooltip placement |
-
-## Accessibility
-
-If there is no `aria-label` attribute, the directive create one based on `oui-tooltip` on the trigger.
-
-## Examples
-
 ### On link
 
 ```html:preview
@@ -57,3 +37,16 @@ If there is no `aria-label` attribute, the directive create one based on `oui-to
 <input type="text" class="oui-input oui-input_inline" placeholder="Bottom Right" oui-tooltip="Tooltip on bottom right" oui-tooltip-placement="bottom-end">
 </div>
 ```
+
+## Accessibility
+
+If there is no `aria-label` attribute, the directive create one based on `oui-tooltip` on the trigger.
+
+## API
+
+| Attribute             | Type   | Binding | One-time Binding | Values                                               | Default   | Description       |
+| ----                  | ----   | ----    | ----             | ----                                                 | ----      | ----              |
+| oui-tooltip           | string | @       | true             |                                                      |           | tooltip text      |
+| oui-tooltip-placement | string | @?      | true             | top,top-start,top-end,bottom,bottom-start,bottom-end | top       | tooltip placement |
+
+


### PR DESCRIPTION
Standardize section order
1. Usage with previews
2. Api
3.Configuration

Remove not useful html example, preview+api are sufficient