### PR TITLE
feat(oui-form-actions): hide cancel button and don't disable submit

### DIFF
--- a/packages/oui-form-actions/README.md
+++ b/packages/oui-form-actions/README.md
@@ -17,12 +17,12 @@
 ### Custom naming
 
 ```html:preview
-<div ng-init="$ctrl.disabled = false" class="oui-doc-preview-only-keep-children">
+<div class="oui-doc-preview-only-keep-children">
     <oui-form-actions
       on-submit="$ctrl.submit()"
       href="#"
-      submit-text="Disable"
-      cancel-text="Reset">
+      submit-text="Apply"
+      cancel-text="Close">
     </oui-form-actions>
 </div>
 ```
@@ -33,12 +33,20 @@
 ```html:preview
 <div ng-init="$ctrl.disabled = false" class="oui-doc-preview-only-keep-children">
     <oui-form-actions
-      on-submit="$ctrl.disabled = true"
-      on-cancel="$ctrl.disabled = false"
-      disabled="$ctrl.disabled">
+      on-submit="$ctrl.lastAction = 'submit'"
+      on-cancel="$ctrl.lastAction = 'cancel'">
     </oui-form-actions>
+    <div>Last action: {{ $ctrl.lastAction }}</div>
 </div>
 ```
+
+### on-submit only
+```html:preview
+<oui-form-actions
+  on-submit="$ctrl.submit()">
+</oui-form-actions>
+```
+In accordance to guidelines, submit button must be always enabled.
 
 ## API
 
@@ -48,6 +56,4 @@
 | on-cancel     | function | &       |                  |                        |           | cancel handler                   |
 | submit-text   | string   | @?      | true             |                        | "Submit"  | submit button text               |
 | cancel-text   | string   | @?      | true             |                        | "Cancel"  | cancel button text               |
-| href          | string   | @?      | true             |                        |           | link url on cancel       |
-| disabled      | boolean  | <?      |                  |                        | false     | disabled flag                    |
-
+| href          | string   | @?      | true             |                        |           | link url on cancel               |

--- a/packages/oui-form-actions/src/form-actions.component.js
+++ b/packages/oui-form-actions/src/form-actions.component.js
@@ -9,8 +9,7 @@ export default {
         cancelText: "@?",
         onSubmit: "&",
         onCancel: "&?",
-        href: "@?",
-        disabled: "<?"
+        href: "@?"
     },
     transclude: true
 };

--- a/packages/oui-form-actions/src/form-actions.controller.js
+++ b/packages/oui-form-actions/src/form-actions.controller.js
@@ -1,5 +1,3 @@
-import { addBooleanParameter } from "@oui-angular/common/component-utils";
-
 export default class {
     constructor ($attrs, ouiFormActions) {
         "ngInject";
@@ -9,7 +7,6 @@ export default class {
     }
 
     $onInit () {
-        addBooleanParameter(this, "disabled");
         this.processTranslations();
     }
 

--- a/packages/oui-form-actions/src/form-actions.html
+++ b/packages/oui-form-actions/src/form-actions.html
@@ -2,7 +2,6 @@
   class="oui-button oui-button_primary"
   ng-click="$ctrl.onSubmit()"
   ng-bind="::$ctrl.submitText"
-  ng-disabled="$ctrl.disabled"
   type="submit">
 </button>
 <button
@@ -10,7 +9,8 @@
   class="oui-button oui-button_link"
   ng-bind="::$ctrl.cancelText"
   ng-click="$ctrl.onCancel()"
-  type="button">
+  type="button"
+  ng-hide="!$ctrl.$attrs.onCancel">
 </button>
 <a
   ng-if="::!!$ctrl.href"

--- a/packages/oui-form-actions/src/index.spec.js
+++ b/packages/oui-form-actions/src/index.spec.js
@@ -76,7 +76,8 @@ describe("ouiFormActions", () => {
             expect(cancelButton.text().trim()).toBe("testCancel");
         });
 
-        it("should disable only submit button", () => {
+        it("should not have submit button disabled at any time", () => {
+            // Submit should always be active according to guidelines
             const component = testUtils.compileTemplate(`
                 <oui-form-actions
                     on-submit="$ctrl.submit()"
@@ -84,10 +85,29 @@ describe("ouiFormActions", () => {
                     disabled>
                 </oui-form-actions>`);
             const submitButton = component.find("button").eq(0);
+
+            expect(submitButton.attr("disabled")).not.toBe("disabled");
+        });
+
+        it("cancel button should be visible if action provided", () => {
+            const component = testUtils.compileTemplate(`
+                <oui-form-actions
+                    on-submit="$ctrl.submit()"
+                    on-cancel="$ctrl.cancel()">
+                </oui-form-actions>`);
             const cancelButton = component.find("button").eq(1);
 
-            expect(submitButton.attr("disabled")).toBe("disabled");
-            expect(cancelButton.attr("disabled")).not.toBe("disabled");
+            expect(cancelButton.hasClass("ng-hide")).toBe(false);
+        });
+
+        it("cancel button should be hidden if no action provided", () => {
+            const component = testUtils.compileTemplate(`
+                <oui-form-actions
+                    on-submit="$ctrl.submit()">
+                </oui-form-actions>`);
+            const cancelButton = component.find("button").eq(1);
+
+            expect(cancelButton.hasClass("ng-hide")).toBe(true);
         });
 
         it("should trigger click on submit button", () => {

--- a/packages/oui-form-actions/src/index.spec.js
+++ b/packages/oui-form-actions/src/index.spec.js
@@ -1,5 +1,7 @@
 describe("ouiFormActions", () => {
     let testUtils;
+    const CANCEL_TEXT = "CancelTest";
+    const SUBMIT_TEXT = "SubmitTest";
 
     beforeEach(angular.mock.module("oui.form-actions"));
     beforeEach(angular.mock.module("oui.test-utils"));
@@ -9,28 +11,25 @@ describe("ouiFormActions", () => {
         testUtils = _TestUtils_;
     }));
 
+    angular.module("test.formActionsConfig", [
+        "oui.form-actions"
+    ]).config(ouiFormActionsProvider => {
+        ouiFormActionsProvider.setTranslations({
+            submit: SUBMIT_TEXT,
+            cancel: CANCEL_TEXT
+        });
+    });
+
     describe("Provider", () => {
         let ouiFormActions;
-
-        angular.module("test.formActionsConfig", [
-            "oui.form-actions"
-        ]).config(ouiFormActionsProvider => {
-            ouiFormActionsProvider.setTranslations({
-                submit: "SubmitTest",
-                cancel: "CancelTest"
-            });
-        });
 
         beforeEach(inject(_ouiFormActions_ => {
             ouiFormActions = _ouiFormActions_;
         }));
 
-        it("should have custom values", () => {
-            const submitTranslation = ouiFormActions.translations.submit;
-            const cancelTranslation = ouiFormActions.translations.cancel;
-
-            expect(submitTranslation).toEqual("SubmitTest");
-            expect(cancelTranslation).toEqual("CancelTest");
+        it("should have custom translation from provider", () => {
+            expect(ouiFormActions.translations.submit).toEqual(SUBMIT_TEXT);
+            expect(ouiFormActions.translations.cancel).toEqual(CANCEL_TEXT);
         });
     });
 
@@ -57,8 +56,8 @@ describe("ouiFormActions", () => {
             const submitButton = component.find("button").eq(0);
             const cancelButton = component.find("button").eq(1);
 
-            expect(submitButton.text().trim()).toBe("SubmitTest");
-            expect(cancelButton.text().trim()).toBe("CancelTest");
+            expect(submitButton.text().trim()).toBe(SUBMIT_TEXT);
+            expect(cancelButton.text().trim()).toBe(CANCEL_TEXT);
         });
 
         it("should display buttons with custom text values", () => {
@@ -89,7 +88,7 @@ describe("ouiFormActions", () => {
             expect(submitButton.attr("disabled")).not.toBe("disabled");
         });
 
-        it("cancel button should be visible if action provided", () => {
+        it("should have visible cancel button when action provided", () => {
             const component = testUtils.compileTemplate(`
                 <oui-form-actions
                     on-submit="$ctrl.submit()"
@@ -100,7 +99,7 @@ describe("ouiFormActions", () => {
             expect(cancelButton.hasClass("ng-hide")).toBe(false);
         });
 
-        it("cancel button should be hidden if no action provided", () => {
+        it("should have an hidden cancel button when no action provided", () => {
             const component = testUtils.compileTemplate(`
                 <oui-form-actions
                     on-submit="$ctrl.submit()">


### PR DESCRIPTION
Some forms don't a cancel boutton so it must be hidden. Guidelines
say that submit button is always enabled, so I've remove the
disabled argument.

Breaks oui-form-actions:disabled, submit function will be called
event if oui-form-actions have a disabled argument.