### PR TITLE
fix(oui-form-actions): rename form-actions-provider

### DIFF
--- a/packages/oui-form-actions/src/form-actions.controller.js
+++ b/packages/oui-form-actions/src/form-actions.controller.js
@@ -1,9 +1,9 @@
 export default class {
-    constructor ($attrs, ouiFormActions) {
+    constructor ($attrs, ouiFormActionsConfiguration) {
         "ngInject";
 
         this.$attrs = $attrs;
-        this.config = ouiFormActions;
+        this.config = ouiFormActionsConfiguration;
     }
 
     $onInit () {

--- a/packages/oui-form-actions/src/index.js
+++ b/packages/oui-form-actions/src/index.js
@@ -3,4 +3,4 @@ import FormActionsProvider from "./form-actions.provider";
 
 angular.module("oui.form-actions", [])
     .component("ouiFormActions", FormActions)
-    .provider("ouiFormActions", FormActionsProvider);
+    .provider("ouiFormActionsConfiguration", FormActionsProvider);

--- a/packages/oui-form-actions/src/index.spec.js
+++ b/packages/oui-form-actions/src/index.spec.js
@@ -13,8 +13,8 @@ describe("ouiFormActions", () => {
 
     angular.module("test.formActionsConfig", [
         "oui.form-actions"
-    ]).config(ouiFormActionsProvider => {
-        ouiFormActionsProvider.setTranslations({
+    ]).config(ouiFormActionsConfigurationProvider => {
+        ouiFormActionsConfigurationProvider.setTranslations({
             submit: SUBMIT_TEXT,
             cancel: CANCEL_TEXT
         });
@@ -23,8 +23,8 @@ describe("ouiFormActions", () => {
     describe("Provider", () => {
         let ouiFormActions;
 
-        beforeEach(inject(_ouiFormActions_ => {
-            ouiFormActions = _ouiFormActions_;
+        beforeEach(inject(_ouiFormActionsConfiguration_ => {
+            ouiFormActions = _ouiFormActionsConfiguration_;
         }));
 
         it("should have custom translation from provider", () => {


### PR DESCRIPTION
rename formActions provider to formActionsConfiguration for uniformity
with other components

Breaks all provider for actions-provider would have to be renamed