### PR TITLE
Fix id attribute for forms and input

### DIFF
--- a/packages/common/component-utils.js
+++ b/packages/common/component-utils.js
@@ -26,8 +26,7 @@ export function addBooleanParameter (controller, parameterName) {
  */
 export function addDefaultParameter (controller, parameterName, defaultValue) {
     if (!angular.isDefined(controller.$attrs[parameterName]) ||
-    angular.isDefined(controller.$attrs[parameterName] &&
-      controller.$attrs[parameterName].trim() === "")) {
+    (angular.isDefined(controller.$attrs[parameterName]) && controller.$attrs[parameterName].trim() === "")) {
         controller[parameterName] = defaultValue;
     }
 }

--- a/packages/oui-checkbox/src/checkbox.controller.js
+++ b/packages/oui-checkbox/src/checkbox.controller.js
@@ -1,4 +1,4 @@
-import { addBooleanParameter } from "@oui-angular/common/component-utils";
+import { addBooleanParameter, addDefaultParameter } from "@oui-angular/common/component-utils";
 
 export default class {
     constructor ($scope, $element, $attrs, $timeout) {
@@ -34,10 +34,7 @@ export default class {
     $onInit () {
         addBooleanParameter(this, "disabled");
         addBooleanParameter(this, "required");
-
-        if (!self.id) {
-            this.id = `oui-checkbox-${this.$scope.$id}`;
-        }
+        addDefaultParameter(this, "id", `ouiCheckbox${this.$scope.$id}`);
     }
 
     _updateIndeterminateState (model) {

--- a/packages/oui-checkbox/src/index.spec.js
+++ b/packages/oui-checkbox/src/index.spec.js
@@ -30,10 +30,10 @@ describe("ouiCheckbox", () => {
                 const element = TestUtils.compileTemplate("<oui-checkbox></oui-checkbox>");
 
                 const checkboxElement = getCheckboxInputElement(element);
-                expect(angular.element(checkboxElement).prop("id")).toMatch(/^oui-checkbox-\d+$/);
+                expect(angular.element(checkboxElement).prop("id")).toMatch(/^ouiCheckbox\d+$/);
 
                 const checkboxLabelElement = getCheckboxLabelElement(element);
-                expect(angular.element(checkboxLabelElement).attr("for")).toMatch(/^oui-checkbox-\d+$/);
+                expect(angular.element(checkboxLabelElement).attr("for")).toMatch(/^ouiCheckbox\d+$/);
             });
 
             it("should set the id for the input and label when defined", () => {

--- a/packages/oui-criteria-adder/src/criteria-adder.controller.js
+++ b/packages/oui-criteria-adder/src/criteria-adder.controller.js
@@ -18,6 +18,8 @@ export default class {
         // Set align to "end" if undefined
         addDefaultParameter(this, "align", "center");
 
+        addDefaultParameter(this, "id", `ouiCriteriaAdder${this.$scope.$id}`);
+
         this.$timeout(() => {
             this.dropdownContent = this.$element[0];
         });
@@ -25,10 +27,6 @@ export default class {
         // Auto select first column
         if (this.properties) {
             this.columnModel = this.properties[0];
-        }
-
-        if (!this.id) {
-            this.id = `oui-criteria-adder-${this.$scope.$id}`;
         }
 
         this.selectableOperators = this.filterSelectableOperators();

--- a/packages/oui-dropdown/src/dropdown.controller.js
+++ b/packages/oui-dropdown/src/dropdown.controller.js
@@ -24,7 +24,7 @@ export default class {
         addDefaultParameter(this, "align", "center");
 
         // Use internal id to map trigger and content with aria-label and aria-labelledby.
-        this.id = `oui-dropdown-${this.$scope.$id}`;
+        this.id = `ouiDropdown${this.$scope.$id}`;
 
         this.documentClickHandler = evt => {
             if ((evt && evt.type === "click") &&

--- a/packages/oui-popover/src/popover.controller.js
+++ b/packages/oui-popover/src/popover.controller.js
@@ -17,7 +17,7 @@ export default class PopoverController {
         this.isPopoverOpen = false;
 
         // Use internal id to map trigger
-        this.id = `oui-popover-${this.$scope.$id}`;
+        this.id = `ouiPopover${this.$scope.$id}`;
 
         if (angular.isUndefined(this.placement)) {
             this.placement = "right";

--- a/packages/oui-radio/README.md
+++ b/packages/oui-radio/README.md
@@ -50,6 +50,7 @@
 ```html:preview
 <div ng-init="$ctrl.value2 = 'a'" class="oui-doc-preview-only-keep-children">
 <oui-radio text="Value A"
+    id="radio2"
     name="oui-radio-2"
     model="$ctrl.value2"
     value="'a'"

--- a/packages/oui-radio/src/index.spec.js
+++ b/packages/oui-radio/src/index.spec.js
@@ -22,10 +22,10 @@ describe("ouiRadio", () => {
                 const element = TestUtils.compileTemplate("<oui-radio></oui-radio>");
 
                 const radioElement = getRadioInputElement(element);
-                expect(angular.element(radioElement).prop("id")).toMatch(/^oui-radio-\d+$/);
+                expect(angular.element(radioElement).prop("id")).toMatch(/^ouiRadio\d+$/);
 
                 const radioLabelElement = getRadioLabelElement(element);
-                expect(angular.element(radioLabelElement).attr("for")).toMatch(/^oui-radio-\d+$/);
+                expect(angular.element(radioLabelElement).attr("for")).toMatch(/^ouiRadio\d+$/);
             });
 
             it("should set the id for the input and label when defined", () => {

--- a/packages/oui-radio/src/index.spec.js
+++ b/packages/oui-radio/src/index.spec.js
@@ -58,7 +58,6 @@ describe("ouiRadio", () => {
                 const element = TestUtils.compileTemplate('<oui-radio id="test"></oui-radio>');
 
                 const radioElement = getRadioInputElement(element);
-                console.log(radioElement);
                 expect(angular.element(radioElement).prop("name")).toBe("test");
             });
         });

--- a/packages/oui-radio/src/index.spec.js
+++ b/packages/oui-radio/src/index.spec.js
@@ -46,6 +46,21 @@ describe("ouiRadio", () => {
                 const radioElement = getRadioInputElement(element);
                 expect(angular.element(radioElement).prop("name")).toBe("test");
             });
+
+            it("should set the name attribute on input when defined with id", () => {
+                const element = TestUtils.compileTemplate('<oui-radio name="test" id="testid"></oui-radio>');
+
+                const radioElement = getRadioInputElement(element);
+                expect(angular.element(radioElement).prop("name")).toBe("test");
+            });
+
+            it("should set the name attribute to id when only id is defined", () => {
+                const element = TestUtils.compileTemplate('<oui-radio id="test"></oui-radio>');
+
+                const radioElement = getRadioInputElement(element);
+                console.log(radioElement);
+                expect(angular.element(radioElement).prop("name")).toBe("test");
+            });
         });
 
         describe("text attribute", () => {

--- a/packages/oui-radio/src/radio.controller.js
+++ b/packages/oui-radio/src/radio.controller.js
@@ -1,4 +1,4 @@
-import { addBooleanParameter } from "@oui-angular/common/component-utils";
+import { addBooleanParameter, addDefaultParameter } from "@oui-angular/common/component-utils";
 
 export default class {
     constructor ($scope, $element, $attrs, $timeout) {
@@ -24,10 +24,7 @@ export default class {
         addBooleanParameter(this, "disabled");
         addBooleanParameter(this, "thumbnail");
         addBooleanParameter(this, "required");
-
-        if (!this.id) {
-            this.id = `oui-radio-${this.$scope.$id}`;
-        }
+        addDefaultParameter(this, "id", `ouiRadio${this.$scope.$id}`);
 
         this.group = this.radioGroup || this.radioToggleGroup;
         if (this.group) {

--- a/packages/oui-radio/src/radio.controller.js
+++ b/packages/oui-radio/src/radio.controller.js
@@ -32,9 +32,8 @@ export default class {
             this.$scope.$watch("$ctrl.group.model", (value) => {
                 this.model = value;
             });
-        } else {
-            this.name = this.id;
-        }
+        } else { addDefaultParameter(this, "name", this.id); }
+
     }
 
     onRadioModelChange (event) {

--- a/packages/oui-select-picker/src/index.spec.js
+++ b/packages/oui-select-picker/src/index.spec.js
@@ -23,10 +23,10 @@ describe("ouiSelectPicker", () => {
                 const element = TestUtils.compileTemplate('<oui-select-picker values="[\'test\']"></oui-select-picker>');
 
                 const radioElement = getRadioInputElement(element);
-                expect(angular.element(radioElement).prop("id")).toMatch(/^oui-select-picker-\d+$/);
+                expect(angular.element(radioElement).prop("id")).toMatch(/^ouiSelectPicker\d+$/);
 
                 const radioLabelElement = getRadioLabelElement(element);
-                expect(angular.element(radioLabelElement).attr("for")).toMatch(/^oui-select-picker-\d+$/);
+                expect(angular.element(radioLabelElement).attr("for")).toMatch(/^ouiSelectPicker\d+$/);
             });
 
             it("should set the id for the input and label when defined", () => {

--- a/packages/oui-select-picker/src/select-picker.controller.js
+++ b/packages/oui-select-picker/src/select-picker.controller.js
@@ -1,4 +1,4 @@
-import { addBooleanParameter } from "@oui-angular/common/component-utils";
+import { addBooleanParameter, addDefaultParameter } from "@oui-angular/common/component-utils";
 import { get } from "lodash";
 
 export default class SelectPickerController {
@@ -28,10 +28,7 @@ export default class SelectPickerController {
     $onInit () {
         addBooleanParameter(this, "disabled");
         addBooleanParameter(this, "required");
-
-        if (!self.id) {
-            this.id = `oui-select-picker-${this.$scope.$id}`;
-        }
+        addDefaultParameter(this, "id", `ouiSelectPicker${this.$scope.$id}`);
 
         if (this.picture) {
             this.isImgPath = /\.(gif|png|jpg)$/.test(this.picture);


### PR DESCRIPTION
Rename id attribute to be in camel case. 
If it contains "-" char,  it won't be handle by angular in order to set validation for forms and access input. 