### PR TITLE
onClick is optional on action-menu-item

### DIFF
--- a/packages/oui-action-menu/src/action-menu-item.component.js
+++ b/packages/oui-action-menu/src/action-menu-item.component.js
@@ -8,6 +8,6 @@ export default {
         ariaLabel: "@?",
         href: "@?",
         external: "<?",
-        onClick: "&"
+        onClick: "&?"
     }
 };


### PR DESCRIPTION
`onClick` should be optional on `action-menu-item`