### PR TITLE
fix(oui-datagrid): wait row promise before displaying cell template

### DIFF
--- a/packages/oui-datagrid/src/cell/cell.controller.js
+++ b/packages/oui-datagrid/src/cell/cell.controller.js
@@ -12,7 +12,13 @@ export default class {
 
         this.$element.css("display", "block");
 
-        this._compileCell();
+        if (this.row && this.row.$promise) {
+            this.row.$promise.finally(() => {
+                this._compileCell();
+            });
+        } else {
+            this._compileCell();
+        }
     }
 
     $onChanges (changes) {


### PR DESCRIPTION
Wait for row promise to be resolved before displaying row template.

For example :
```
<oui-column>
    <span data-ng-if="$row.foo">Foo</span>
    <span data-ng-if="!$row.foo">Bar</span>
</oui-column>
```

Will display "Bar" during on the fly row loading which is not intended (we expect cell to be left blank). This fix wait the promise to be resolved and then compile the cell template.