### PR TITLE
fix(oui-datagrid): add refresh & update events

### DIFF
--- a/packages/oui-datagrid/src/datagrid.html
+++ b/packages/oui-datagrid/src/datagrid.html
@@ -77,7 +77,7 @@
             </div>
         </div>
     </div>
-    <div ng-hide="!$ctrl.displayedRows.length || $ctrl.firstLoading">
+    <div ng-hide="!$ctrl.displayedRows.length || $ctrl.firstLoading || $ctrl.loading">
         <oui-pagination
             class="oui-datagrid-panel__pagination"
             current-offset="$ctrl.paging.offset"


### PR DESCRIPTION
Add two events : "datagrid-refresh" & "datagrid-update-rows". In order to be able to refresh and alter rows while using on the fly row loading.

For example :
```js
// From another controller
$scope.$broadcast("datagrid-update-rows", (rows) => {
    const user = _.find(rows, { name: "foo" });
    if (user) {
        user.name = "bar"; // alter row
    }
});
```