### PR TITLE
chore(oui-calendar): bump version of flatpickr to v4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
-    "popper.js": "^1.12.9"
+    "popper.js": "^1.12.9",
+    "flatpickr": "4.5.0"
   },
   "devDependencies": {
     "angular": "~1.6.1",
@@ -61,7 +62,6 @@
     "eslint-loader": "^1.9.0",
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.15.3",
-    "flatpickr": "4.5.0",
     "html-loader": "^0.5.1",
     "html-webpack-plugin": "^2.26.0",
     "istanbul-instrumenter-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-loader": "^1.9.0",
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.15.3",
-    "flatpickr": "4.4.4",
+    "flatpickr": "4.5.0",
     "html-loader": "^0.5.1",
     "html-webpack-plugin": "^2.26.0",
     "istanbul-instrumenter-loader": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3443,9 +3443,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.4.4.tgz#fdeb083ca3d580eecb822a4080f67b06f0294fc7"
+flatpickr@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.5.0.tgz#f72c7164a1c24e3ad419e3b2209d1a2d3604724a"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
https://github.com/flatpickr/flatpickr/releases/tag/v4.5.0
Resolves the logs `Error{}` when launching the unit tests