### PR TITLE
fix(oui-action-menu): disable one-time binding for the text attribute

### DIFF
--- a/packages/oui-action-menu/README.md
+++ b/packages/oui-action-menu/README.md
@@ -87,8 +87,8 @@
 
 | Attribute         | Type            | Binding | One-time binding | Values                    | Default             | Description                        |
 | ----              | ----            | ----    | ----             | ----                      | ----                | ----                               |
-| `text`            | string          | @       | yes              |                           |                     | button label                       |
-| `aria-label`      | string          | @?      | yes              |                           |                     | accessibility label                |
+| `text`            | string          | @       |                  |                           |                     | button label                       |
+| `aria-label`      | string          | @?      |                  |                           |                     | accessibility label                |
 | `href`            | string          | @?      | yes              |                           |                     | hypertext link (link)              |
 | `disabled`        | boolean         | <?      |                  |                           | `false`             | disable (button).                  |
 | `external`        | boolean         | @?      | yes              |                           |                     | display external icon (link)       |

--- a/packages/oui-action-menu/src/action-menu-item-button.html
+++ b/packages/oui-action-menu/src/action-menu-item-button.html
@@ -4,7 +4,7 @@
     class="oui-button oui-button_action-menu"
     type="button"
     ng-click="$ctrl.onClick()"
-    ng-bind="::$ctrl.text"
-    ng-attr-aria-label="{{::$ctrl.ariaLabel}}"
+    ng-bind="$ctrl.text"
+    ng-attr-aria-label="{{$ctrl.ariaLabel}}"
     ng-disabled="$ctrl.disabled"></button>
 </div>


### PR DESCRIPTION
I was asked by CX to upgrade more parts of the manager to the new ui-kit style (see SCDC-439).
But I stumbled upon an issue when adapting a button to the `oui-action-menu-item` component.

The button is supposed to toggle an option between "enabled" and "disabled" states, and therefore changes its text to exhibit what's going to happen if the user clicks on it.

It was working fine with the old system but now that I migrated it to a `oui-action-menu-item`, the text is one-time binding, preventing the underlying change to appear, keeping the button in an "activated" state regardless of the real value.

So I switched to one-way `<` binding.