### PR TITLE
fix: rename title attribute to heading

### DIFF
--- a/packages/oui-back-button/README.md
+++ b/packages/oui-back-button/README.md
@@ -7,7 +7,7 @@
 ### Default
 
 ```html:preview
-<oui-back-button href="#" data-title="Title">
+<oui-back-button href="#" heading="Title">
 </oui-back-button>
 ```
 
@@ -32,6 +32,6 @@
 | id            | string   | @?      | true             |                     |                        | id attribute of the input           |
 | name          | string   | @?      | true             |                     |                        | name attribute of the input         |
 | aria-label    | string   | @?      | true             |                     |                        | accessibility label                 |
-| title         | string   | @?      | true             |                     |                        | text of the header                  |
+| heading       | string   | @?      | true             |                     |                        | text of the header                  |
 | on-click      | function | &?      |                  |                     |                        | callback on component click         |
 | href          | string   | @?      | true             |                     |                        | link url                            |

--- a/packages/oui-back-button/src/back-button.component.js
+++ b/packages/oui-back-button/src/back-button.component.js
@@ -8,7 +8,8 @@ export default {
         id: "@?",
         name: "@?",
         ariaLabel: "@?",
-        title: "@?",
+        heading: "@?",
+        title: "@?", // Deprecated: Replaced by 'heading'
         onClick: "&?",
         href: "@?"
     }

--- a/packages/oui-back-button/src/back-button.controller.js
+++ b/packages/oui-back-button/src/back-button.controller.js
@@ -1,10 +1,18 @@
 export default class {
-    constructor ($element, $timeout, $window) {
+    constructor ($attrs, $element, $timeout, $window) {
         "ngInject";
 
+        this.$attrs = $attrs;
         this.$element = $element;
         this.$timeout = $timeout;
         this.$window = $window;
+    }
+
+    $onInit () {
+        // Deprecated: Support for 'title' attribute
+        if (!!this.$attrs.title && !this.$attrs.heading) {
+            this.heading = this.title;
+        }
     }
 
     $postLink () {

--- a/packages/oui-back-button/src/back-button.html
+++ b/packages/oui-back-button/src/back-button.html
@@ -12,4 +12,4 @@
    ng-href="{{:: $ctrl.href }}">
   <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
 </a>
-<h2 class="oui-back-button_title oui-header_2">{{:: $ctrl.title }}</h2>
+<h2 class="oui-back-button_title oui-header_2" ng-bind="::$ctrl.heading"></h2>

--- a/packages/oui-back-button/src/index.spec.js
+++ b/packages/oui-back-button/src/index.spec.js
@@ -59,7 +59,7 @@ describe("ouiBackButton", () => {
 
         it("should have a title", () => {
             const title = "foo";
-            const element = compile(`<oui-back-button data-title="${title}"></oui-back-button>`);
+            const element = compile(`<oui-back-button heading="${title}"></oui-back-button>`);
 
             $timeout.flush();
 

--- a/packages/oui-collapsible/README.md
+++ b/packages/oui-collapsible/README.md
@@ -7,7 +7,7 @@
 ### Normal
 
 ```html:preview
-<oui-collapsible title="Title" aria-label="Action">
+<oui-collapsible heading="Title" aria-label="Action">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis semper ligula nec fringilla tempor. In rhoncus ullamcorper feugiat. Phasellus vel ipsum vitae neque varius luctus. Proin id iaculis arcu. Fusce justo arcu, egestas vel nulla nec, dictum cursus lacus. Aenean elementum vel odio quis rutrum. In quis tellus in neque vulputate rhoncus vitae ut justo. Ut dignissim varius est in consequat. Donec nisi mauris, pellentesque condimentum congue in, blandit ut arcu. In et elit ipsum.
 </oui-collapsible>
 ```
@@ -15,7 +15,7 @@
 ### Expanded
 
 ```html:preview
-<oui-collapsible title="Title" aria-label="Action" expanded="true">
+<oui-collapsible heading="Title" aria-label="Action" expanded="true">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis semper ligula nec fringilla tempor. In rhoncus ullamcorper feugiat. Phasellus vel ipsum vitae neque varius luctus. Proin id iaculis arcu. Fusce justo arcu, egestas vel nulla nec, dictum cursus lacus. Aenean elementum vel odio quis rutrum. In quis tellus in neque vulputate rhoncus vitae ut justo. Ut dignissim varius est in consequat. Donec nisi mauris, pellentesque condimentum congue in, blandit ut arcu. In et elit ipsum.
 </oui-collapsible>
 ```
@@ -26,6 +26,6 @@
 
 | Attribute     | Type      | Binding | One-time binding | Values | Default   | Description
 | ----          | ----      | ----    | ----             | ----   | ----      | ----
-| `title`       | string    | @       |                  |        |           | collapsible title
+| `heading`     | string    | @       |                  |        |           | collapsible heading
 | `aria-label`  | string    | @?      | yes              |        |           | accessibility label
 | `expanded`    | boolean   | <?      | yes              |        | `false`   | initial expanded state

--- a/packages/oui-collapsible/src/collapsible.component.js
+++ b/packages/oui-collapsible/src/collapsible.component.js
@@ -6,7 +6,7 @@ export default {
     controller,
     bindings: {
         id: "@",
-        title: "@",
+        heading: "@",
         ariaLabel: "@?",
         expanded: "<?"
     },

--- a/packages/oui-collapsible/src/collapsible.html
+++ b/packages/oui-collapsible/src/collapsible.html
@@ -3,7 +3,7 @@
     aria-label="{{::$ctrl.ariaLabel}}"
     aria-expanded="{{$ctrl.expanded}}"
     aria-controls="{{::$ctrl.id}}">
-    {{::$ctrl.title}}
+    {{::$ctrl.heading}}
     <i class="oui-icon oui-icon-chevron-down oui-collapsible__toggle-icon" aria-hidden="true"></i>
 </button>
 <div class="oui-collapsible__wrapper" ng-style="{ 'height': $ctrl.wrapperHeight }">

--- a/packages/oui-collapsible/src/index.spec.js
+++ b/packages/oui-collapsible/src/index.spec.js
@@ -17,20 +17,20 @@ describe("ouiCollapsible", () => {
     }
 
     describe("Component", () => {
-        it("should have the correct title", () => {
-            const titleText = "Collapsible title";
+        it("should have the correct heading", () => {
+            const headingText = "Collapsible heading";
             const element = TestUtils.compileTemplate(`
-                <oui-collapsible title="${titleText}" aria-label="Action"></oui-collapsible>`
+                <oui-collapsible heading="${headingText}" aria-label="Action"></oui-collapsible>`
             );
 
             const headerEl = getHeaderElement(element);
-            expect(headerEl.innerText).toContain(titleText);
+            expect(headerEl.innerText).toContain(headingText);
         });
 
         it("should have the correct aria-label", () => {
             const ariaLabel = "Action";
             const element = TestUtils.compileTemplate(`
-                <oui-collapsible title="Title" aria-label="${ariaLabel}"></oui-collapsible>`
+                <oui-collapsible heading="Title" aria-label="${ariaLabel}"></oui-collapsible>`
             );
 
             const headerEl = getHeaderElement(element);
@@ -40,7 +40,7 @@ describe("ouiCollapsible", () => {
 
         it("should expand and collapse on header click", () => {
             const element = TestUtils.compileTemplate(`
-                <oui-collapsible title="Title" aria-label="Action"></oui-collapsible>`
+                <oui-collapsible heading="Title" aria-label="Action"></oui-collapsible>`
             );
 
             const headerEl = angular.element(getHeaderElement(element));
@@ -56,7 +56,7 @@ describe("ouiCollapsible", () => {
 
         it("should be expanded", () => {
             const element = TestUtils.compileTemplate(`
-                <oui-collapsible title="Title" aria-label="Action" expanded="true"></oui-collapsible>`
+                <oui-collapsible heading="Title" aria-label="Action" expanded="true"></oui-collapsible>`
             );
             const headerEl = angular.element(getHeaderElement(element));
             expect(headerEl.attr("aria-expanded")).toBe("true");
@@ -64,7 +64,7 @@ describe("ouiCollapsible", () => {
 
         it("should transclude the contents into the collapsible body", () => {
             const element = TestUtils.compileTemplate(`
-                <oui-collapsible title="Title" aria-label="Action" expanded="true">
+                <oui-collapsible heading="Title" aria-label="Action" expanded="true">
                     <div class="custom-content">Collapsible body</div>
                 </oui-collapsible>`
             );

--- a/packages/oui-modal/README.md
+++ b/packages/oui-modal/README.md
@@ -8,7 +8,7 @@
 <div ng-init="$ctrl.cancel = false; $ctrl.confirm = false"
     class="oui-doc-preview-only-keep-children">
 <oui-modal
-    data-title="Modal title"
+    heading="Modal title"
     primary-action="$ctrl.confirm = true"
     primary-label="Ok"
     secondary-action="$ctrl.cancel = true"
@@ -27,7 +27,7 @@
 <div ng-init="$ctrl.cancel2 = false; $ctrl.confirm2 = false"
     class="oui-doc-preview-only-keep-children">
 <oui-modal
-    data-title="Modal title"
+    heading="Modal title"
     primary-action="$ctrl.confirm2 = true"
     primary-label="Save"
     on-dismiss="$ctrl.cancel2 = true">
@@ -43,7 +43,7 @@
 ```html:preview
 <div ng-init="$ctrl.loading = true" class="oui-doc-preview-only-keep-children">
 <oui-modal
-    data-title="Loading modal title"
+    heading="Loading modal title"
     primary-action="$ctrl.confirm = true"
     primary-label="Ok"
     secondary-action="$ctrl.cancel = true"
@@ -64,7 +64,7 @@
 <div ng-init="$ctrl.dismiss = false"
     class="oui-doc-preview-only-keep-children">
 <oui-modal
-    data-title="Warning modal"
+    heading="Warning modal"
     primary-action="$ctrl.dismiss = true"
     primary-label="Ok"
     on-dismiss="$ctrl.dismiss = true"
@@ -78,7 +78,7 @@
 
 | Attribute           | Type     | Binding | One-time Binding | Values                 | Default           | Description                               |
 | ----                | ----     | ----    | ----             | ----                   | ----              | ----                                      |
-| `data-title`        | string   | @       | yes              |                        |                   | modal title                               |
+| `heading`        | string   | @       | yes              |                        |                   | modal title                               |
 | `primary-action`    | function | &?      |                  |                        |                   | confirmation callback                     |
 | `primary-label`     | string   | @?      | yes              |                        |                   | confirmation label                        |
 | `secondary-action`  | function | &?      |                  |                        |                   | cancellation callback                     |

--- a/packages/oui-modal/src/index.spec.js
+++ b/packages/oui-modal/src/index.spec.js
@@ -25,7 +25,7 @@ describe("ouiModal", () => {
         it("should display a modal", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Modal title">
+                    heading="Modal title">
                 </oui-modal>
             `);
 
@@ -35,7 +35,7 @@ describe("ouiModal", () => {
         it("should display a title", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="{{$ctrl.title}}">
+                    heading="{{$ctrl.title}}">
                 </oui-modal>
             `, {
                 title
@@ -50,7 +50,7 @@ describe("ouiModal", () => {
         it("should display a content", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title">
+                    heading="Title">
                     {{::$ctrl.body}}
                 </oui-modal>
             `, {
@@ -66,7 +66,7 @@ describe("ouiModal", () => {
         it("should display a footer", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title">
+                    heading="Title">
                 </oui-modal>
             `);
 
@@ -78,7 +78,7 @@ describe("ouiModal", () => {
         it("should display primary button in the footer", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     primary-label="{{::$ctrl.primaryLabel}}">
                 </oui-modal>
             `, {
@@ -96,7 +96,7 @@ describe("ouiModal", () => {
             const primarySpy = jasmine.createSpy("primaryClick");
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     primary-label="Save"
                     primary-action="$ctrl.primarySpy()">
                 </oui-modal>
@@ -111,7 +111,7 @@ describe("ouiModal", () => {
         it("should display secondary button in the footer", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     secondary-label="{{::$ctrl.secondaryLabel}}">
                 </oui-modal>
             `, {
@@ -128,7 +128,7 @@ describe("ouiModal", () => {
         it("should display an overlay when loading", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     loading="true">
                 </oui-modal>
             `);
@@ -142,7 +142,7 @@ describe("ouiModal", () => {
         it("should display a warning modal", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     loading="true"
                     type="warning">
                 </oui-modal>
@@ -157,7 +157,7 @@ describe("ouiModal", () => {
         it("should disable buttons when loading", () => {
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     primary-label="{{::$ctrl.primaryLabel}}"
                     secondary-label="{{::$ctrl.secondaryLabel}}"
                     loading="true">
@@ -181,7 +181,7 @@ describe("ouiModal", () => {
             const secondarySpy = jasmine.createSpy("secondaryClick");
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     secondary-label="Save"
                     secondary-action="$ctrl.secondarySpy()">
                 </oui-modal>
@@ -197,7 +197,7 @@ describe("ouiModal", () => {
             const dismissSpy = jasmine.createSpy("dismiss");
             const element = TestUtils.compileTemplate(`
                 <oui-modal
-                    title="Title"
+                    heading="Title"
                     on-dismiss="$ctrl.dismissSpy()">
                 </oui-modal>
             `, {

--- a/packages/oui-modal/src/modal.component.js
+++ b/packages/oui-modal/src/modal.component.js
@@ -5,7 +5,8 @@ export default {
     template,
     controller,
     bindings: {
-        title: "@?",
+        heading: "@?",
+        title: "@?", // Deprecated: Replaced by 'heading'
         primaryAction: "&?",
         primaryLabel: "@?",
         secondaryAction: "&?",

--- a/packages/oui-modal/src/modal.controller.js
+++ b/packages/oui-modal/src/modal.controller.js
@@ -9,5 +9,10 @@ export default class {
 
     $onInit () {
         addBooleanParameter(this, "loading");
+
+        // Deprecated: Support for 'title' attribute
+        if (!!this.$attrs.title && !this.$attrs.heading) {
+            this.heading = this.title;
+        }
     }
 }

--- a/packages/oui-modal/src/modal.html
+++ b/packages/oui-modal/src/modal.html
@@ -17,8 +17,8 @@
       <oui-spinner></oui-spinner>
     </div>
     <h2 class="oui-modal__title"
-        ng-bind="::$ctrl.title"
-        ng-if="::!!$ctrl.title">
+        ng-bind="::$ctrl.heading"
+        ng-if="::!!$ctrl.heading">
     </h2>
     <div ng-transclude></div>
   </div>

--- a/packages/oui-slideshow/README.md
+++ b/packages/oui-slideshow/README.md
@@ -9,22 +9,22 @@
 ```html:preview
 <div class="oui-doc-preview-only-keep-children" style="padding:50px 35px;background-color:rgba(0,0,0,0.3)">
     <oui-slideshow>
-        <oui-slideshow-panel title="New feature"
+        <oui-slideshow-panel heading="New feature"
                                      text="Display your infrastructure as a list"
                                      picture="https://upload.wikimedia.org/wikipedia/commons/4/4a/Cercle_rouge_100%25.svg">
         </oui-slideshow-panel>
-        <oui-slideshow-panel title="Introducing Ad-Sync"
+        <oui-slideshow-panel heading="Introducing Ad-Sync"
                                      text="Designed to help you synchronize your local Active Directory with your OVH Active Directory."
                                      picture="https://upload.wikimedia.org/wikipedia/commons/4/4a/Cercle_rouge_100%25.svg"
                                      href="http://www.ovh.com/"
                                      label="Discover">
         </oui-slideshow-panel>
-        <oui-slideshow-panel title="New features available in your emails pages"
+        <oui-slideshow-panel heading="New features available in your emails pages"
                                      text="Introducing Ad-Sync, designed to help you synchronize your local Active Directory with your OVH Active Directory."
                                      href="http://www.ovh.com/"
                                      label="Discover">
         </oui-slideshow-panel>
-        <oui-slideshow-panel title="Introducing Ad-Sync"
+        <oui-slideshow-panel heading="Introducing Ad-Sync"
                                          text="Designed to help you synchronize your local Active Directory with your OVH Active Directory."
                                          picture="https://upload.wikimedia.org/wikipedia/commons/4/4a/Cercle_rouge_100%25.svg"
                                          href="http://www.ovh.com/"
@@ -39,7 +39,7 @@
 ```html:preview
 <div class="oui-doc-preview-only-keep-children" style="padding:50px 35px;background-color:rgba(0,0,0,0.3)">
     <oui-slideshow loading>
-        <oui-slideshow-panel title="Panel 1" text="This is the first panel description"></oui-slideshow-panel>
+        <oui-slideshow-panel heading="Panel 1" text="This is the first panel description"></oui-slideshow-panel>
     </oui-slideshow>
 </div>
 ```
@@ -49,9 +49,9 @@
 ```html:preview
 <div class="oui-doc-preview-only-keep-children" style="padding:50px 35px;background-color:rgba(0,0,0,0.3)">
     <oui-slideshow loop>
-        <oui-slideshow-panel title="Panel 1" text="This is the first panel description"></oui-slideshow-panel>
-        <oui-slideshow-panel title="Panel 2" text="This is the second panel description"></oui-slideshow-panel>
-        <oui-slideshow-panel title="Panel 3" text="This is the third panel description"></oui-slideshow-panel>
+        <oui-slideshow-panel heading="Panel 1" text="This is the first panel description"></oui-slideshow-panel>
+        <oui-slideshow-panel heading="Panel 2" text="This is the second panel description"></oui-slideshow-panel>
+        <oui-slideshow-panel heading="Panel 3" text="This is the third panel description"></oui-slideshow-panel>
     </oui-slideshow>
 </div>
 ```
@@ -60,7 +60,7 @@
 ```html:preview
 <div class="oui-doc-preview-only-keep-children" style="padding:50px 35px;background-color:rgba(0,0,0,0.3)">
 <oui-slideshow>
-    <oui-slideshow-panel title="External link"
+    <oui-slideshow-panel heading="External link"
                                  text="Introducing Ad-Sync, designed to help you synchronize your local Active Directory with your OVH Active Directory."
                                  href="#"
                                  label="Discover"
@@ -85,7 +85,7 @@
 
 | Attribute           | Type     | Binding | One-time Binding | Values          | Default          | Description                                     |
 | ----                | ----     | ----    | ----             | ----            | ----             | ----                                            |
-| `title`             | string   | @?      | yes              |                 |                  | the panel's title                               |
+| `heading`           | string   | @?      | yes              |                 |                  | the panel's heading                             |
 | `text`              | string   | @?      | yes              |                 |                  | the panel's description                         |
 | `picture`           | string   | @?      | yes              |                 |                  | the panel's picture / illustration              |
 | `on-click`          | function | &?      |                  |                 |                  | on-click handler (button)                       |

--- a/packages/oui-slideshow/src/index.spec.js
+++ b/packages/oui-slideshow/src/index.spec.js
@@ -55,19 +55,6 @@ describe("ouiSlideshow", () => {
                 getDismissButton(element).triggerHandler("click");
                 expect(dismissSpy).toHaveBeenCalled();
             });
-
-            /* it("should dismiss modal on escape key's trigger", () => {
-                const dismissSpy = jasmine.createSpy("dismiss");
-                const element = TestUtils.compileTemplate('<oui-slideshow on-dismiss="$ctrl.dismissSpy()"></oui-slideshow>', {
-                    dismissSpy
-                });
-                $timeout.flush();
-                $document.triggerHandler({
-                    type: "keydown",
-                    keyCode: 27
-                });
-                expect(dismissSpy).toHaveBeenCalled();
-            }); */
         });
 
         describe("SlideshowPanel", () => {

--- a/packages/oui-slideshow/src/slideshow-panel.component.js
+++ b/packages/oui-slideshow/src/slideshow-panel.component.js
@@ -5,7 +5,7 @@ export default {
     template,
     controller,
     bindings: {
-        title: "@?",
+        heading: "@?",
         text: "@?",
         picture: "@?",
         onClick: "&?",

--- a/packages/oui-slideshow/src/slideshow-panel.html
+++ b/packages/oui-slideshow/src/slideshow-panel.html
@@ -6,10 +6,10 @@
         </div>
     </div>
     <div class="oui-slideshow-panel__container"
-         ng-if="::$ctrl.title || $ctrl.text">
+         ng-if="::$ctrl.heading || $ctrl.text">
         <div class="oui-slideshow-panel__title"
-             ng-bind="::$ctrl.title"
-             ng-if="::$ctrl.title">
+             ng-bind="::$ctrl.heading"
+             ng-if="::$ctrl.heading">
         </div>
         <div class="oui-slideshow-panel__text"
              ng-bind-html="::$ctrl.text"


### PR DESCRIPTION
Change `title` attribute to `heading` of components whose its value define an heading instead of a tooltip. The purpose is to avoid using the same attribute name as existing attribute for a different use.

For components already released, I added a support to ease the switch. 
It concern `oui-back-button` and `oui-modal`.

`oui-select` has a `title` attribute, but it's well used. So no need of changing it.