### PR TITLE
fix(oui-action-menu): allow to disable action menu dynamically

### DIFF
--- a/packages/oui-action-menu/src/action-menu.component.js
+++ b/packages/oui-action-menu/src/action-menu.component.js
@@ -8,7 +8,8 @@ export default {
         text: "@",
         align: "@?",
         ariaLabel: "@?",
-        compact: "<?"
+        compact: "<?",
+        disabled: "<?"
     },
     transclude: true
 };


### PR DESCRIPTION
Before : You could only put `disabled` attribute on `oui-action-menu` in a static way
Now: `disabled` attribute accept dynamic values 