### PR TITLE
feat(oui-tile): add external link handle

### DIFF
--- a/packages/oui-tile/README.md
+++ b/packages/oui-tile/README.md
@@ -89,6 +89,7 @@
 | `href`              | string   | @?      | yes              |                        |                   | button link url                           |
 | `on-click`          | funcion  | &?      |                  |                        |                   | button action callback                    |
 | `aria-label`        | string   | @?      |                  |                        | `null`            | accessibility label                       |
+| `external`          | boolean  | <?      | yes              |                        | `false`           | open in new tab and display external icon
 
 ### oui-tile-definition
 

--- a/packages/oui-tile/src/button/tile-button.component.js
+++ b/packages/oui-tile/src/button/tile-button.component.js
@@ -8,7 +8,8 @@ export default {
         text: "@?",
         onClick: "&?",
         href: "@?",
-        ariaLabel: "@?"
+        ariaLabel: "@?",
+        external: "<?"
     },
     transclude: true
 };

--- a/packages/oui-tile/src/button/tile-button.controller.js
+++ b/packages/oui-tile/src/button/tile-button.controller.js
@@ -1,3 +1,5 @@
+import { addBooleanParameter } from "@oui-angular/common/component-utils";
+
 export default class {
     constructor ($attrs, $element, $timeout) {
         "ngInject";
@@ -5,6 +7,10 @@ export default class {
         this.$attrs = $attrs;
         this.$element = $element;
         this.$timeout = $timeout;
+    }
+
+    $onInit () {
+        addBooleanParameter(this, "external");
     }
 
     $postLink () {

--- a/packages/oui-tile/src/button/tile-button.html
+++ b/packages/oui-tile/src/button/tile-button.html
@@ -5,13 +5,19 @@
     ng-click="$ctrl.onClick()"
     ng-attr-aria-label="{{ :: $ctrl.ariaLabel }}">
     <span ng-transclude>{{ :: $ctrl.text }}</span>
-    <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
+    <span class="oui-icon oui-icon-chevron-right" aria-hidden="true"></span>
 </button>
 <a
     ng-if="::!!$ctrl.href"
     class="oui-tile__button oui-button oui-button_link oui-button_icon-right oui-button_full-width"
     ng-href="{{:: $ctrl.href }}"
+    ng-attr-rel="{{:: $ctrl.external ? 'noopener' : undefined }}"
+    ng-attr-target="{{:: $ctrl.external ? '_blank' : undefined }}"
     ng-attr-aria-label="{{ :: $ctrl.ariaLabel }}">
     <span ng-transclude>{{ :: $ctrl.text }}</span>
-    <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
+    <span class="oui-icon oui-icon-external_link"
+          aria-hidden="true"
+          ng-if="::$ctrl.external"></span>
+    <span class="oui-icon oui-icon-chevron-right"
+          aria-hidden="true"></span>
 </a>

--- a/packages/oui-tile/src/index.spec.js
+++ b/packages/oui-tile/src/index.spec.js
@@ -65,6 +65,20 @@ describe("ouiTile", () => {
             expect(button.attr("href")).toBe(url);
         });
 
+        it("should add rel and target attributes if tile button is external link", () => {
+            const relAttr = "noopener";
+            const targetAttr = "_blank";
+            const element = TestUtils.compileTemplate(
+                `<oui-tile>
+                    <oui-tile-button href="http://myurl.com" text="text" external></oui-tile-button>
+                </oui-tile>`);
+
+            const button = getTileButton(element);
+
+            expect(button.attr("rel")).toBe(relAttr);
+            expect(button.attr("target")).toBe(targetAttr);
+        });
+
         it("should handle click in a button tile", () => {
             const clickSpy = jasmine.createSpy("click");
             const element = TestUtils.compileTemplate(


### PR DESCRIPTION
### Handle external link on oui-tile-button
Allow use of external link to open link in new tab, display external link icon

(Need merge of https://github.com/ovh-ux/ovh-ui-kit/pull/243 on ovh-ui-kit to be functional)