### PR TITLE
feat(oui-select-picker): add default light templates

### DIFF
--- a/packages/oui-select-picker/src/select-picker.component.js
+++ b/packages/oui-select-picker/src/select-picker.component.js
@@ -20,6 +20,7 @@ export default {
         values: "<",
         disabled: "<?",
         required: "<?",
-        onChange: "&?"
+        onChange: "&?",
+        variant: "@?"
     }
 };

--- a/packages/oui-select-picker/src/select-picker.controller.js
+++ b/packages/oui-select-picker/src/select-picker.controller.js
@@ -24,12 +24,18 @@ export default class SelectPickerController {
 
             this.labelElement = this.$element.find("label");
             this.labelElement.on("click", event => this.openSelectMenu(event));
+
+            // Avoid apply undefined class if this.variant is not already set
+            if (this.variant) {
+                this.$element.addClass(`oui-select-picker_${this.variant}`);
+            }
         });
     }
 
     $onInit () {
         addBooleanParameter(this, "disabled");
         addBooleanParameter(this, "required");
+        addDefaultParameter(this, "variant", "default");
         addDefaultParameter(this, "id", `ouiSelectPicker${this.$scope.$id}`);
 
         // Deprecated: Support for 'text' attribute


### PR DESCRIPTION
## oui-select-picker default and light templates

(Related to https://github.com/ovh-ux/ovh-ui-kit/pull/275)