### PR TITLE
fix(oui-navbar): fix state attributes on component links

### DIFF
--- a/packages/oui-navbar/src/navbar.html
+++ b/packages/oui-navbar/src/navbar.html
@@ -29,6 +29,8 @@
         name="{{::managerLink.name}}"
         text="{{::managerLink.heading || managerLink.title}}"
         href="{{::managerLink.href || managerLink.url}}"
+        state="{{::!!managerLink.state ? managerLink.state : null}}"
+        state-params="::!!managerLink.stateParams ? managerLink.stateParams : null"
         variant="{{::managerLink.isPrimary ? 'primary' : 'secondary'}}"
         aria-label="{{::!!managerLink.label ? managerLink.label : null}}"
         ng-repeat="managerLink in ::$ctrl.mainLinks track by $index"


### PR DESCRIPTION
If main links was done with attribute `main-links`, it doesn't supported the states. Only the href/url property.  This fix will resolve the problem.