### PR TITLE
fix(oui-select-picker): prevent leaving blank space

### DIFF
--- a/packages/oui-select-picker/src/select-picker.html
+++ b/packages/oui-select-picker/src/select-picker.html
@@ -28,7 +28,7 @@
             ng-bind=":: $ctrl.description"
             ng-if="$ctrl.description"></span>
     <span class="oui-select-picker__value-container oui-select-picker__section"
-        ng-if="$ctrl.values.length">
+        ng-if="$ctrl.values.length && $ctrl.match">
         <span class="oui-select-picker__value"
                 ng-bind=":: $ctrl.getFirstValueMatch($ctrl.match)"
                 ng-if="$ctrl.values.length === 1"></span>


### PR DESCRIPTION
## Fix/oui select picker blank section

### Description of the Change

Avoid leaving blank section if match value is not used and custom sections are added to the picker