### PR TITLE
 fix(oui-calendar): fix boolean parameters 

### DIFF
--- a/packages/oui-calendar/README.md
+++ b/packages/oui-calendar/README.md
@@ -61,6 +61,17 @@
 </div>
 ```
 
+### Enabling time
+
+Use `enable-time` to show time selection after a date is selected.
+
+```html:preview
+<oui-calendar model="$ctrl.weekModel" format="Y-m-d H:i" enable-time>
+</oui-calendar>
+```
+
+**Note**: See [Flatpickr documentation](https://flatpickr.js.org/examples/#time-picker) for more information.
+
 ### Disabling dates
 
 Use `disable-date` to make certain dates unavailable for selection.
@@ -168,7 +179,7 @@ Use `mode` to set a different selection mode for the calendar
 | `min-date`        | object    | <?        | yes               | See [Supplying Dates](https://flatpickr.js.org/examples/#supplying-dates-for-flatpickr)   | n/a       | specifies the minimum/earliest date (inclusively) allowed for selection
 | `disable-date`    | array     | <?        | yes               | See [Supplying Dates](https://flatpickr.js.org/examples/#supplying-dates-for-flatpickr)   | n/a       | make certain dates unavailable for selection
 | `enable-date`     | array     | <?        | yes               | See [Supplying Dates](https://flatpickr.js.org/examples/#supplying-dates-for-flatpickr)   | n/a       | make certain dates only available for selection
-| `enable-time`     | boolean   | <?        | yes               | See [Options](https://flatpickr.js.org/options/)                                          | n/a       | enables time picker
+| `enable-time`     | boolean   | <?        | yes               | `true`, `false`                                                                           | `false`   | enables time selection
 | `week-numbers`    | boolean   | <?        | yes               | `true`, `false`                                                                           | `false`   | week numbers flag
 | `disabled`        | boolean   | <?        | no                | `true`, `false`                                                                           | `false`   | disabled flag
 | `required`        | boolean   | <?        | no                | `true`, `false`                                                                           | `false`   | required flag

--- a/packages/oui-calendar/src/calendar.controller.js
+++ b/packages/oui-calendar/src/calendar.controller.js
@@ -82,8 +82,10 @@ export default class {
     $onInit () {
         addBooleanParameter(this, "appendToBody");
         addBooleanParameter(this, "disabled");
+        addBooleanParameter(this, "enableTime");
         addBooleanParameter(this, "inline");
         addBooleanParameter(this, "required");
+        addBooleanParameter(this, "static");
         addBooleanParameter(this, "weekNumbers");
 
         this.initCalendarInstance();


### PR DESCRIPTION
UK-66

* Add enable-time example
* Fix boolean parameters `enable-time` and `static`

Related to https://github.com/ovh-ux/ovh-ui-kit/pull/301