### PR TITLE
fix(oui-select): prevent required validation to trigger on select

### DIFF
--- a/packages/oui-select/src/select.html
+++ b/packages/oui-select/src/select.html
@@ -3,7 +3,7 @@
         ng-model="$ctrl.model"
         search-enabled="false"
         ng-attr-title="{{::$ctrl.title}}"
-        ng-required="$ctrl.required"
+        ng-required="$ctrl.required && !$select.open"
         ng-disabled="$ctrl.disabled"
         on-blur="$ctrl.onUiSelectBlur()"
         on-focus="$ctrl.onUiSelectFocus()"


### PR DESCRIPTION
## Prevent angular form "required" to trigger on item selection

When option is clicked form validation is triggered which cause the element to go in error status for a small instant

### Description of the Change

Prevent form validation if select is open 

Example can be found : 
MANAGER-1840
