### PR TITLE
feat(oui-dropdown): allow click on link items

### DIFF
--- a/packages/oui-dropdown/src/index.spec.js
+++ b/packages/oui-dropdown/src/index.spec.js
@@ -212,6 +212,32 @@ describe("ouiDropdown", () => {
                 expect(link.attr("target")).toBe("_blank");
                 expect(link.attr("rel")).toBe("noopener");
             });
+
+            it("should call click callback", () => {
+                const onLinkClickSpy = jasmine.createSpy("onLinkClickSpy");
+                const onButtonClickSpy = jasmine.createSpy("onButtonClickSpy");
+                const element = TestUtils.compileTemplate(`
+                    <oui-dropdown>
+                        <oui-dropdown-trigger text="Actions"></oui-dropdown-trigger>
+                        <oui-dropdown-content>
+                            <oui-dropdown-item text="Lorem ipsum" href="#" on-click="$ctrl.onLinkClick()"></oui-dropdown-item>
+                            <oui-dropdown-item text="Lorem ipsum" on-click="$ctrl.onButtonClick()"></oui-dropdown-item>
+                            <oui-dropdown-item text="Lorem ipsum" href="#"></oui-dropdown-item>
+                        </oui-dropdown-content>
+                    </oui-dropdown>
+                `, {
+                    onLinkClick: onLinkClickSpy,
+                    onButtonClick: onButtonClickSpy
+                });
+
+                $timeout.flush();
+                const items = angular.element(element[0].querySelectorAll("oui-dropdown-item")).children();
+                angular.element(items[0]).triggerHandler("click");
+                angular.element(items[1]).triggerHandler("click");
+
+                expect(onLinkClickSpy).toHaveBeenCalled();
+                expect(onButtonClickSpy).toHaveBeenCalled();
+            });
         });
 
         describe("Group", () => {

--- a/packages/oui-dropdown/src/item/dropdown-item.html
+++ b/packages/oui-dropdown/src/item/dropdown-item.html
@@ -12,7 +12,8 @@
     ng-if="::!!$ctrl.href"
     ng-href="{{::$ctrl.href}}"
     ng-attr-target="{{::$ctrl.linkTarget}}"
-    ng-attr-rel="{{::$ctrl.linkRel}}">
+    ng-attr-rel="{{::$ctrl.linkRel}}"
+    ng-click="$ctrl.onClick()">
     <span ng-transclude>{{::$ctrl.text}}</span>
     <span ng-if="::$ctrl.external"
         class="oui-icon oui-icon-external_link"
@@ -23,6 +24,7 @@
     role="menuitem"
     ng-if="::!!$ctrl.state"
     ui-sref="{{::$ctrl.getFullSref()}}"
+    ng-click="$ctrl.onClick()"
     ng-transclude>
     {{::$ctrl.text}}
 </a>


### PR DESCRIPTION
## Allow click on all `oui-dropdown-item`


### Description of the Change

Before : `on-click` callback was not available for element with `state` or `href`
Now: `on-click` callback is available for all `oui-dropdown-item` (and therefore `oui-action-menu-item`)
