### PR TITLE
fix(oui-select-picker): default value

### DIFF
--- a/packages/oui-select-picker/src/select-picker.controller.js
+++ b/packages/oui-select-picker/src/select-picker.controller.js
@@ -31,12 +31,10 @@ export default class SelectPickerController {
         }
 
         if (this.values) {
-            if (this.values.length === 1) {
-                this.selectedValue = this.values[0];
-            }
-
             if (this.model && find(this.values, this.model)) {
                 this.selectedValue = this.model;
+            } else {
+                [this.selectedValue] = this.values;
             }
         }
 


### PR DESCRIPTION
Close MBP-34

### Requirements

When there are multiple select-pickers and when more than 1 select picker have multiple 'values' (values.length > 1), then the value attribute of multiple radio buttons created out of the select picker have undefined values i.e. the value attributes are not unique

## Default Value Auto Set


### Description of the Change

To fix this issue, the first value of the values array is taken as the default value (selectedValue) for a select-picker so that the select pickers have unique values