### PR TITLE
fix(oui-select): nested property support for match api

### DIFF
--- a/packages/oui-select/src/select.controller.js
+++ b/packages/oui-select/src/select.controller.js
@@ -1,4 +1,5 @@
 import { addBooleanParameter } from "@ovh-ui/common/component-utils";
+import get from "lodash/get";
 
 export default class {
     constructor ($attrs, $compile, $element, $scope, $timeout) {
@@ -58,5 +59,9 @@ export default class {
         }
 
         this.onFocus();
+    }
+
+    getPropertyValue (item) {
+        return get(item, this.match, null);
     }
 }

--- a/packages/oui-select/src/templates/match.html
+++ b/packages/oui-select/src/templates/match.html
@@ -15,7 +15,7 @@
         </span>
         <span class="ui-select-match-text"
             ng-hide="$select.isEmpty()"
-            ng-bind-html="$select.selected[$ctrl.match] || $select.selected">
+            ng-bind-html="$ctrl.getPropertyValue($select.selected) || $select.selected">
         </span>
         <span class="oui-icon oui-icon-chevron-down"></span>
     </span>


### PR DESCRIPTION
support nested property like "region.name" on match input in oui-select component

Closes #MANAGER-2056

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
support nested property like "region.name" on match input in oui-select component

### Description of the Change
oui-select-picker uses oui-select. This issue happens If match property has nested properties like 'region.name.' The reason is that of a bug in match.html used by oui-select. It does not take the nested property into consideration.

```
 <span class="ui-select-match-text"
            ng-hide="$select.isEmpty()"
            ng-bind-html="$select.selected[$ctrl.match] || $select.selected">
  </span>
```
in the above code, we straight away getting a property on the object. But the supplied property is a nested property.

Solution: used loadash get that supports nested property.

### Benefits

<!-- optional -->
<!-- What benefits will be achieved by the code change? -->

### Possible Drawbacks
none

### Applicable Issues
MANAGER-2056
