### PR TITLE
fix(oui-select): fix match template of oui-ui-select theme

### DIFF
--- a/packages/oui-select/src/templates/match.html
+++ b/packages/oui-select/src/templates/match.html
@@ -14,8 +14,13 @@
             ng-bind="::$select.placeholder">
         </span>
         <span class="ui-select-match-text"
-            ng-hide="$select.isEmpty()"
-            ng-bind-html="$select.selected[$ctrl.match] || $select.selected">
+            ng-hide="$select.isEmpty()">
+            <span data-ng-if="$ctrl.match"
+                  ng-bind-html="$select.selected[$ctrl.match] || $select.selected">
+            </span>
+            <span data-ng-if="!$ctrl.match"
+                  ng-transclude>
+            </span>
         </span>
         <span class="oui-icon oui-icon-chevron-down"></span>
     </span>


### PR DESCRIPTION
Allow to use `oui-ui-select` theme directly with ui-select directive. This allow to customize the selected item.
This checks if match attribute is set and if not set, transclude the ui-select-match directive content.