### PR TITLE
fix(oui-dropdown): fix dropdown menu positioning

### DIFF
--- a/packages/oui-dropdown/src/dropdown.controller.js
+++ b/packages/oui-dropdown/src/dropdown.controller.js
@@ -145,12 +145,7 @@ export default class {
         this.popperElement.style.minWidth = `${this.getTriggerWidth()}px`;
 
         this.popper = new Popper(this.triggerElement, this.popperElement, {
-            placement,
-            modifiers: {
-                preventOverflow: {
-                    boundariesElement: this.$document[0].body
-                }
-            }
+            placement
         });
     }
 


### PR DESCRIPTION
Hello,

### Description of the Change

Currently, if you have a dropdown inside a DOM element with a `position: absolute`, the dropdown will pop at the wrong place.

Default parameter of Popper.js fix the issue.

### Benefits

Dropdown will now display correctly in that case

### Possible Drawbacks

I can't reproduce an issue, which explains why we choose to override some modifiers. 

It is possible that in other cases, it is broken. However, we use the default behavior of Popper.js, so the risk is minimal I think.

### Applicable Issues

Internal use: OM-266
