### PR TITLE
fix(oui-file): fix input hidden error from ng 1.7.6

### DIFF
--- a/packages/oui-file/src/file.html
+++ b/packages/oui-file/src/file.html
@@ -1,18 +1,21 @@
 <!-- Controls -->
-<input type="hidden"
+<!-- Using [hidden] cause errors with ng 1.7.6, -->
+<!-- We use [text] hidden by css to avoid it -->
+<input class="oui-file__input oui-file__input_hidden" type="text"
+    autocomplete="off"
     ng-attr-id="{{::$ctrl.id}}"
     ng-attr-name="{{::$ctrl.name}}"
     ng-disabled="$ctrl.disabled"
     ng-required="$ctrl.required"
     ng-model="$ctrl.model">
-<input class="oui-file__input" type="file"
+<input class="oui-file__input oui-file__input_file" type="file"
     ng-if="::!$ctrl.attachments"
     ng-attr-id="{{::$ctrl.selectorId}}"
     ng-attr-accept="{{::$ctrl.accept}}"
     ng-attr-size="{{::$ctrl.size}}"
     ng-disabled="$ctrl.disabled"
     tabindex="-1">
-<input class="oui-file__input" type="file"
+<input class="oui-file__input oui-file__input_file" type="file"
     ng-if="::$ctrl.attachments"
     ng-attr-id="{{::$ctrl.selectorId}}"
     ng-attr-accept="{{::$ctrl.accept}}"

--- a/packages/oui-file/src/index.spec.js
+++ b/packages/oui-file/src/index.spec.js
@@ -6,8 +6,8 @@ describe("ouiFile", () => {
 
     const getAttachments = (element) => element[0].querySelector(".oui-file-attachments");
     const getDropArea = (element) => element[0].querySelector(".oui-file-droparea");
-    const getInputFile = (element) => element[0].querySelector("input[type='file']");
-    const getInputHidden = (element) => element[0].querySelector("input[type='hidden']");
+    const getInputFile = (element) => element[0].querySelector(".oui-file__input_file");
+    const getInputHidden = (element) => element[0].querySelector(".oui-file__input_hidden");
     const getMultipleSelector = (element) => element[0].querySelector(".oui-file-multiple");
     const getCustomSelector = (element) => element[0].querySelector(".oui-file-selector");
 


### PR DESCRIPTION
Since [AngularJS 1.7.6](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#176-gravity-manipulation-2019-01-17), there is an error when using `input[hidden]` in oui-file.

To avoid this, the `input[hidden]` has been changed to `input[text]`, hidden using CSS.