### PR TITLE
docs(oui-criteria): typo on basic example usage

### DIFF
--- a/packages/oui-criteria/README.md
+++ b/packages/oui-criteria/README.md
@@ -10,7 +10,7 @@
 <oui-criteria
     model="$ctrl.basicModel"
     properties="$ctrl.inputValue">
-</oui-criteria-adder>
+</oui-criteria>
 ```
 
 ### With search field


### PR DESCRIPTION
# Typo on basic example usage

### 📝 Documentation

2e9022a — docs(oui-criteria): typo on basic example usage
