### PR TITLE
docs(oui-page-header): remove typo in example

### DIFF
--- a/packages/oui-guide-menu/README.md
+++ b/packages/oui-guide-menu/README.md
@@ -35,7 +35,7 @@
 ### In Page-header
 
 ```html:preview
-<oui-page-header heading="My title" description="My subtitle">à
+<oui-page-header heading="My title" description="My subtitle">
     <oui-guide-menu text="Guides">
         <oui-guide-menu-group label="Section 1">
             <oui-guide-menu-item href="#">Guide 1 (link)</oui-guide-menu-item>

--- a/packages/oui-page-header/README.md
+++ b/packages/oui-page-header/README.md
@@ -18,7 +18,7 @@
 ### With guide
 
 ```html:preview
-<oui-page-header heading="My title" description="My subtitle">à
+<oui-page-header heading="My title" description="My subtitle">
     <oui-guide-menu text="Guides">
         <oui-guide-menu-group label="Section 1">
             <oui-guide-menu-item text="Guide 1 (link)" href="#"></oui-guide-menu-item>


### PR DESCRIPTION
## docs(oui-page-header): remove typo in example

### Description of the Change

91e2ace — docs(oui-page-header): remove typo in example
4562036 — docs(oui-guide-menu): remove typo in example

/cc @AxelPeter @FredericEspiau 

