### PR TITLE
fix(oui-stepper): use ng-if instead of ng-show for step form loading

### DIFF
--- a/packages/oui-stepper/src/step-form/step-form.controller.js
+++ b/packages/oui-stepper/src/step-form/step-form.controller.js
@@ -15,6 +15,7 @@ export default class StepFormController {
         addBooleanParameter(this, "disabled");
         addBooleanParameter(this, "editable");
         addBooleanParameter(this, "skippable");
+        addBooleanParameter(this, "loading");
 
         // Add default name
         addDefaultParameter(this, "name", `ouiStepForm${this.$scope.$id}`);

--- a/packages/oui-stepper/src/step-form/step-form.html
+++ b/packages/oui-stepper/src/step-form/step-form.html
@@ -28,7 +28,7 @@
         <legend class="oui-stepper__description" ng-bind="$ctrl.description"></legend>
 
         <!-- Step Loader -->
-        <section class="oui-stepper__loader" ng-show="$ctrl.loading">
+        <section class="oui-stepper__loader" ng-if="$ctrl.loading">
             <oui-spinner size="s"></oui-spinner>
             <span class="oui-stepper__label-loader"
                 ng-bind="$ctrl.loadingText">
@@ -36,7 +36,7 @@
         </section>
         <!-- /Step Loader -->
 
-        <section ng-show="!$ctrl.loading">
+        <section ng-if="!$ctrl.loading">
             <div ng-transclude></div>
         </section>
 


### PR DESCRIPTION
## Replace `ng-show` with `ng-if` for `oui-step-form` loading

### Description of the Change

Prevent the content from being transcluded while the loading isn't finish

### Benefits

Avoid troubles with transcluded elements needing asynchronous data
