### PR TITLE
fix(oui-clipboard): set button type

### DIFF
--- a/packages/oui-clipboard/src/clipboard.html
+++ b/packages/oui-clipboard/src/clipboard.html
@@ -7,6 +7,7 @@
     oui-tooltip="{{$ctrl.tooltipText}}"
     readonly>
 <button class="oui-clipboard__button oui-button"
+    type="button"
     ng-attr-aria-label="{{::$ctrl.translations.copyToClipboardLabel}}">
     <span class="oui-icon oui-icon-copy-normal"></span>
 </button>


### PR DESCRIPTION
## fix(oui-clipboard): set button type

### Description of the Change

Avoid to submit form when a `oui-clipboard` element is present in a form.

28ab699 — fix(oui-clipboard): set button type

