### PR TITLE
feat: allow to pass placement to oui-action-menu

### DIFF
--- a/packages/oui-action-menu/README.md
+++ b/packages/oui-action-menu/README.md
@@ -28,6 +28,19 @@
 </oui-action-menu>
 ```
 
+### Open on the side 
+
+```html:preview
+<oui-action-menu align="right" compact text="Actions">
+    <oui-action-menu-item href="#">Action 1 (link)</oui-action-menu-item>
+    <oui-action-menu-item on-click="$ctrl.onActionClick()">Action 2 (button)</oui-action-menu-item>
+    <oui-action-menu-item disabled>Action 3 (disabled)</oui-action-menu-item>
+    <oui-action-menu-divider></oui-action-menu-divider>
+    <oui-action-menu-item href="#" external>External link</oui-action-menu-item>
+</oui-action-menu>
+```
+
+
 ### Disabled
 
 ```html:preview
@@ -93,7 +106,7 @@
 | ----              | ----            | ----    | ----             | ----                      | ----       | ----
 | `text`            | string          | @       | yes              | n/a                       | n/a        | button label
 | `aria-label`      | string          | @?      | yes              | n/a                       | n/a        | accessibility label
-| `align`           | string          | @?      | yes              | `start`, `center`, `end`  | `center`   | menu alignment
+| `align`           | string    | @?        | yes               |  See [Popper placements](https://popper.js.org/popper-documentation.html#Popper.placements)  | `bottom-start`   | modifier for alignment
 | `compact`         | boolean         | <?      | yes              | `true`, `false`           | `false`    | use the compact button
 | `disabled`        | boolean         | <?      | no               | `true`, `false`           | `false`    | disable flag
 

--- a/packages/oui-dropdown/README.md
+++ b/packages/oui-dropdown/README.md
@@ -239,7 +239,7 @@ See <a href="#!/oui-angular/guide-menu">Guide menu component</a>.
 
 | Attribute         | Type      | Binding   | One-time Binding  | Values                    | Default   | Description
 | ----              | ----      | ----      | ----              | ----                      | ----      | ----
-| `align`           | string    | @?        | yes               | `start`, `center`, `end`  | `start`   | modifier for alignment
+| `align`           | string    | @?        | yes               |  See [Popper placements](https://popper.js.org/popper-documentation.html#Popper.placements)  | `bottom-start`   | modifier for alignment
 | `arrow`           | boolean   | <?        | no                | `true`, `false`           | `false`   | display the dropdown arrow
 | `persistent`      | boolean   | <?        | no                | `true`, `false`           | `false`   | prevent dropdown to close on click
 

--- a/packages/oui-dropdown/src/dropdown.controller.js
+++ b/packages/oui-dropdown/src/dropdown.controller.js
@@ -21,7 +21,7 @@ export default class {
 
         addBooleanParameter(this, "arrow");
         addBooleanParameter(this, "persistent");
-        addDefaultParameter(this, "align", "start");
+        addDefaultParameter(this, "align", "bottom-start");
 
         // Use internal id to map trigger and content with aria-label and aria-labelledby.
         this.id = `ouiDropdown${this.$scope.$id}`;
@@ -131,14 +131,18 @@ export default class {
     }
 
     createPopper () {
-        let placement = "bottom";
+        let placement = this.align;
 
         if (["start", "end"].indexOf(this.align) >= 0) {
-            placement += `-${this.align}`;
+            placement = `bottom-${this.align}`;
+        }
+
+        if (["center"].indexOf(this.align) >= 0) {
+            placement = "bottom";
         }
 
         // Let Popper.js manage the arrow position when it's centered (default).
-        if (this.arrowElement && placement === "bottom") {
+        if (this.arrowElement && this.align === "center") {
             this.arrowElement.setAttribute("x-arrow", "");
         }
 

--- a/packages/oui-dropdown/src/index.spec.js
+++ b/packages/oui-dropdown/src/index.spec.js
@@ -91,9 +91,9 @@ describe("ouiDropdown", () => {
             expect(element[0].querySelector("[x-arrow]")).toBeDefined();
         });
 
-        it("should display the dropdown aligned with the left border", () => {
+        it("should display at bottom with the arrow centered by default", () => {
             const element = TestUtils.compileTemplate(`
-                <oui-dropdown align="start">
+                <oui-dropdown arrow>
                   <button class="oui-button" oui-dropdown-trigger></button>
                   <div oui-dropdown-content>
                     <b>the menu</b>
@@ -107,9 +107,25 @@ describe("ouiDropdown", () => {
             controller.toggle();
 
             expect(controller.popper.options.placement).toEqual("bottom-start");
+            expect(element[0].querySelector("[x-arrow]")).toBeDefined();
+        });
 
-            // Popper.js must not manage the arrow position in this case.
-            expect(element[0].querySelector("[x-arrow]")).toBeNull();
+        it("should give the correct placement", () => {
+            const element = TestUtils.compileTemplate(`
+                <oui-dropdown align="left-start">
+                  <button class="oui-button" oui-dropdown-trigger></button>
+                  <div oui-dropdown-content>
+                    <b>the menu</b>
+                  </div>
+                </oui-dropdown>`
+            );
+
+            $timeout.flush();
+
+            const controller = element.controller("ouiDropdown");
+            controller.toggle();
+
+            expect(controller.popper.options.placement).toEqual("left-start");
         });
 
         it("should display the dropdown aligned with the right border", () => {


### PR DESCRIPTION
## Allow to place `oui-action-menu` 


### Description of the Change

Add `placement` parameter to be able to open menu when it's wanted 

### Benefits

If a menu is quite large, this can help to find best placement especially for responsive 
