### PR TITLE
fix(oui-select): remove invalid hideErrors method call

### DIFF
--- a/packages/oui-select/src/select.controller.js
+++ b/packages/oui-select/src/select.controller.js
@@ -110,7 +110,6 @@ export default class {
             if (this.multiple || this.$select.open || (!this.$select.open && !this.isOpen)) {
                 if (this.fieldCtrl) {
                     this.fieldCtrl.hasFocus = true;
-                    this.fieldCtrl.hideErrors(this.$select.$element[0], this.name);
                 }
 
                 this.onFocus();


### PR DESCRIPTION
The method "hideErrors" doesn't exists anymore in oui-field controller