### PR TITLE
fix(oui-dropdown): prevent popper from changing the placement

### DIFF
--- a/packages/oui-dropdown/src/dropdown.controller.js
+++ b/packages/oui-dropdown/src/dropdown.controller.js
@@ -154,7 +154,7 @@ export default class {
             placement,
             modifiers: {
                 flip: {
-                    boundariesElement: "viewport"
+                    enabled: false
                 },
                 keepTogether: {
                     enabled: true


### PR DESCRIPTION
## Prevent popper from changing the placement

Prevent Popper from opening dropdown another way that specified 
