### PR TITLE
feat(oui-tile): add transclude for term and actions

### DIFF
--- a/packages/oui-tile/README.md
+++ b/packages/oui-tile/README.md
@@ -34,8 +34,19 @@
 ```html:preview
 <oui-tile heading="Title">
     <oui-tile-definition term="Term" description="This is a description"></oui-tile-definition>
-    <oui-tile-definition term="Term">
+    <oui-tile-definition>
+        <oui-tile-term>Term</oui-tile-term>
         <oui-tile-description>This is a description</oui-tile-description>
+        <oui-tile-actions>
+            <oui-dropdown placement="end">
+                <oui-dropdown-trigger text="Actions"></oui-dropdown-trigger>
+                <oui-dropdown-content>
+                    <oui-dropdown-item href="#">Action 1</oui-dropdown-item>
+                    <oui-dropdown-item href="#">Action 2</oui-dropdown-item>
+                    <oui-dropdown-item href="#">Action 3</oui-dropdown-item>
+                </oui-dropdown-content>
+            </oui-dropdown>
+        </oui-tile-actions>
     </oui-tile-definition>
     <oui-tile-definition term="Term" term-popover="This is a popover text" description="This is a description"></oui-tile-definition>
     <oui-tile-definition term="Progress">
@@ -104,3 +115,19 @@
 | `term`            | string   | @?         | yes               | n/a               | n/a       | definition term item
 | `term-popover`    | string   | @?         | yes               | n/a               | n/a       | definition term item popover
 | `description`     | string   | @?         | yes               | n/a               | n/a       | definition description item
+
+### Transclude slots
+
+| Attribute                   | Description
+| ----                        | ----
+| `<oui-title-term>`          | definition term slot, override attribute `term`
+| `<oui-title-description>`   | definition description slot, override attribute `description`
+| `<oui-title-actions>`       | definition actions slot
+
+```html
+<oui-title-definition>
+    <oui-title-term>Term</oui-title-term>
+    <oui-title-description>Descriptions</oui-title-description>
+    <oui-title-actions>Actions</oui-title-actions>
+<oui-title-definition>
+```

--- a/packages/oui-tile/src/definition/tile-definition.component.js
+++ b/packages/oui-tile/src/definition/tile-definition.component.js
@@ -10,7 +10,9 @@ export default {
         description: "@?"
     },
     transclude: {
+        actionMenuSlot: "?ouiActionMenu",
+        actionsSlot: "?ouiTileActions",
         descriptionSlot: "?ouiTileDescription",
-        actionSlot: "?ouiActionMenu"
+        termSlot: "?ouiTileTerm"
     }
 };

--- a/packages/oui-tile/src/definition/tile-definition.controller.js
+++ b/packages/oui-tile/src/definition/tile-definition.controller.js
@@ -9,7 +9,7 @@ export default class {
     }
 
     $onInit () {
-        this.transcludeAction = this.$transclude.isSlotFilled("actionSlot");
+        this.transcludeActions = this.$transclude.isSlotFilled("actionsSlot") || this.$transclude.isSlotFilled("actionMenuSlot");
     }
 
     $postLink () {

--- a/packages/oui-tile/src/definition/tile-definition.html
+++ b/packages/oui-tile/src/definition/tile-definition.html
@@ -1,5 +1,5 @@
 <dl class="oui-tile__definition">
-    <dt class="oui-tile__term">
+    <dt class="oui-tile__term" ng-transclude="termSlot">
         <span ng-bind="::$ctrl.term"></span>
         <oui-popover ng-if="::!!$ctrl.termPopover">
             <button type="button" class="oui-popover-button" aria-label="Help" oui-popover-trigger></button>
@@ -13,6 +13,7 @@
     </dd>
 </dl>
 <div class="oui-tile__actions"
-    ng-if="$ctrl.transcludeAction"
-    ng-transclude="actionSlot">
+    ng-if="$ctrl.transcludeActions">
+    <div ng-transclude="actionMenuSlot"></div>
+    <div ng-transclude="actionsSlot"></div>
 </div>

--- a/packages/oui-tile/src/index.spec.js
+++ b/packages/oui-tile/src/index.spec.js
@@ -15,6 +15,7 @@ describe("ouiTile", () => {
     const getTileButton = (element) => angular.element(element[0].querySelector(".oui-tile__button"));
     const getTileDefinitionTerm = (element) => angular.element(element[0].querySelector(".oui-tile__term"));
     const getTileDefinitionDesc = (element) => angular.element(element[0].querySelector(".oui-tile__description"));
+    const getTileDefinitionActions = element => angular.element(element[0].querySelector(".oui-tile__actions"));
     const getActionMenu = (element) => angular.element(element[0].querySelector(".oui-tile__actions"));
 
     describe("Component", () => {
@@ -157,14 +158,15 @@ describe("ouiTile", () => {
             const description = "my description";
             const element = TestUtils.compileTemplate(
                 `<oui-tile>
-                    <oui-tile-definition term="${term}" description="${description}"></oui-tile-button>
+                    <oui-tile-definition term="${term}" description="${description}"></oui-tile-definition>
                 </oui-tile>`);
 
             const element2 = TestUtils.compileTemplate(
                 `<oui-tile>
-                    <oui-tile-definition term="${term}">
+                    <oui-tile-definition>
+                        <oui-tile-term>${term}</oui-tile-term>
                         <oui-tile-description>${description}</oui-tile-description>
-                    </oui-tile-button>
+                    </oui-tile-definition>
                 </oui-tile>`);
 
             expect(getTileDefinitionTerm(element).html()).toContain(term);
@@ -174,12 +176,26 @@ describe("ouiTile", () => {
             expect(getTileDefinitionDesc(element2).html()).toContain(description);
         });
 
+
+        it("should display actions", () => {
+            const actions = "my actions";
+            const element = TestUtils.compileTemplate(
+                `<oui-tile>
+                    <oui-tile-definition>
+                        <oui-tile-actions>${actions}</oui-tile-actions>
+                    </oui-tile-definition>
+                </oui-tile>`
+            );
+
+            expect(getTileDefinitionActions(element).html()).toContain(actions);
+        });
+
         it("should define a term-popover", () => {
             const termPopover = "my popover";
 
             const element = TestUtils.compileTemplate(
                 `<oui-tile>
-                    <oui-tile-definition term-popover="${termPopover}"></oui-tile-button>
+                    <oui-tile-definition term-popover="${termPopover}"></oui-tile-definition>
                 </oui-tile>`);
 
             const popoverButton = angular.element(element[0].querySelector(".oui-popover-button"));
@@ -196,12 +212,12 @@ describe("ouiTile", () => {
                         <oui-action-menu>
                             <oui-action-menu-item></oui-action-menu-item>
                         </oui-action-menu>
-                    </oui-tile-button>
+                    </oui-tile-definition>
                 </oui-tile>`);
 
             const element2 = TestUtils.compileTemplate(
                 `<oui-tile>
-                    <oui-tile-definition></oui-tile-button>
+                    <oui-tile-definition></oui-tile-definition>
                 </oui-tile>`);
 
             expect(getActionMenu(element).length).not.toBe(0);


### PR DESCRIPTION
- add transclude `<oui-tile-term>`
- add transclude `<oui-tile-actions>`
- update stories
- update documentation
- update unit tests

Allow to add custom tags, to facilitate the migration.
For example:

```html
<div class="oui-tile__item">
    <dl class="oui-tile__definition">
        <dt class="oui-tile__term">
            <service-expiration-label></service-expiration-label>
        </dt>
        <dd class="oui-tile__description">
            <service-expiration-date></service-expiration-date>
        </dd>
    </dl>
    <div class="oui-tile__actions">
        <service-expiration-date></service-expiration-date>
    </div>
</div>
```