### PR TITLE
feat(oui-criteria): add ability to hide operators field

### DIFF
--- a/packages/oui-criteria/README.md
+++ b/packages/oui-criteria/README.md
@@ -65,12 +65,13 @@
 
 `properties` is an array of objects defined as this:
 
-| Attribute     | Type      | Description
-| ----          | ----      | -----
-| `name`        | string    | Property to filter (can be a nested one)
-| `title`       | string    | Human readeable title for the property
-| `type`        | string    | Data type
-| `typeOptions` | object    | Specific options
+| Attribute         | Type      | Description
+| ----              | ----      | -----
+| `name`            | string    | Property to filter (can be a nested one)
+| `title`           | string    | Human readeable title for the property
+| `hideOperators`   | boolean   | Hide operators field. If `true`, The first entry of the operators will be applied when submitted.
+| `type`            | string    | Data type
+| `typeOptions`     | object    | Specific options
 
 ## Deprecated
 

--- a/packages/oui-criteria/src/adder/criteria-adder.html
+++ b/packages/oui-criteria/src/adder/criteria-adder.html
@@ -24,7 +24,8 @@
             <!-- /Column field -->
 
             <!-- Operator field -->
-            <oui-field label="{{::$ctrl.translations.operator_label}}" size="m">
+            <oui-field label="{{::$ctrl.translations.operator_label}}" size="m"
+                ng-hide="$ctrl.columnModel.hideOperators">
                 <oui-select
                     ng-attr-id="{{::$ctrl.id}}Operator"
                     name="{{::$ctrl.name}}Operator"

--- a/packages/oui-criteria/src/adder/criteria-adder.spec.data.json
+++ b/packages/oui-criteria/src/adder/criteria-adder.spec.data.json
@@ -41,5 +41,10 @@
                 "contains"
             ]
         }
+    }, {
+        "name": "example.string.noOperators",
+        "title": "Example No operators",
+        "hideOperators": true,
+        "type": "string"
     }]
 }

--- a/packages/oui-criteria/src/adder/criteria-adder.spec.js
+++ b/packages/oui-criteria/src/adder/criteria-adder.spec.js
@@ -124,6 +124,18 @@ describe("ouiCriteriaAdder", () => {
                     title: "contains"
                 }]);
             });
+
+            it("should hide operators filed", () => {
+                const propertyMeta = find(mockData.properties, { name: "example.string.noOperators" });
+                controller.columnModel = propertyMeta;
+                controller.onColumnChange();
+
+                // Must digest to apply ngHide
+                component.scope().$digest();
+
+                const fieldClassname = component.find("oui-field").eq(1).attr("class");
+                expect(fieldClassname).toContain("ng-hide");
+            });
         });
 
         describe("Column type = string", () => {


### PR DESCRIPTION
Backport from https://github.com/ovh-ux/ovh-ui-kit/pull/476

- Add support of `hideOperators` property
- Update unit tests
- Update documentation
