### PR TITLE
fix(oui-numeric): keyboard support to change value

### DIFF
--- a/packages/oui-numeric/src/index.spec.js
+++ b/packages/oui-numeric/src/index.spec.js
@@ -58,11 +58,11 @@ describe("ouiNumeric", () => {
             elt.find("input").controller("ngModel").$setViewValue("1");
             expect(scope.foo).toBe(1);
             elt.find("input").controller("ngModel").$setViewValue("hello");
-            expect(scope.foo).toBe(1);
+            expect(scope.foo).toBe(undefined);
             elt.find("input").controller("ngModel").$setViewValue(value1);
             expect(scope.foo).toBe(value1);
             elt.find("input").controller("ngModel").$setViewValue(value2);
-            expect(scope.foo).toBe(value1);
+            expect(scope.foo).toBe(undefined);
         });
 
         it("should decrement value when clicking first button", () => {
@@ -154,6 +154,17 @@ describe("ouiNumeric", () => {
             elt.find("input").controller("ngModel").$setViewValue("10");
             const value = 10;
             expect(scope.onChange).toHaveBeenCalledWith(value);
+        });
+
+        it("should not trigger onChange callback when invalid value is entered", () => {
+            const elt = angular.element('<oui-numeric min="4" model="foo" on-change="onChange(modelValue)"></oui-numeric>');
+            const scope = $rootScope.$new();
+            scope.foo = 5;
+            scope.onChange = jasmine.createSpy("onChange");
+            $compile(elt)(scope);
+            scope.$digest();
+            elt.find("input").controller("ngModel").$setViewValue("3");
+            expect(scope.onChange).not.toHaveBeenCalled();
         });
 
         it("should not trigger onChange callback when value is updated with no changes", () => {

--- a/packages/oui-numeric/src/numeric.controller.js
+++ b/packages/oui-numeric/src/numeric.controller.js
@@ -106,16 +106,10 @@ export default class {
     }
 
     onInputChanged () {
-    // if user clears input, set value to lower bound
-        if (this.model === null) {
-            this.setModelValue(this.min);
-
-            // if user input is not valid, ignore it and reset to previous value
-        } else if (!angular.isNumber(this.model) ||
-               this.model < this.min ||
-               this.model > this.max) {
-            this.model = this.previousValue;
-        } else {
+        if (this.model !== null &&
+            angular.isNumber(this.model) &&
+            this.model >= this.min &&
+            this.model <= this.max) {
             this.setModelValue(this.model);
         }
     }

--- a/packages/oui-numeric/src/numeric.html
+++ b/packages/oui-numeric/src/numeric.html
@@ -9,6 +9,9 @@
 <input class="oui-input oui-input_number"
     type="number"
     role="slider"
+    required
+    ng-attr-min="{{ $ctrl.min }}"
+    ng-attr-max="{{ $ctrl.max }}"
     ng-attr-id="{{:: $ctrl.id }}"
     ng-attr-name="{{:: $ctrl.name }}"
     ng-attr-aria-valuemin="{{ $ctrl.min }}"


### PR DESCRIPTION
## Title of the Pull Requests <!-- required -->
Allow OUI numeric value to be changed using keyboard

### Description of the Change
Value in OUI numeric can be changed/removed/deleted using keyboard
Showing error if value is empty, less than min or more than max
Changed and added new test cases

### Benefits
Its possible to update numeric value using keyboard always

### Possible Drawbacks
none

### Applicable Issues
MBP-505
