### PR TITLE
fix(oui-header-tabs): remove replaceWith that cause item duplication

### DIFF
--- a/packages/oui-header-tabs/src/header-tabs-item.controller.js
+++ b/packages/oui-header-tabs/src/header-tabs-item.controller.js
@@ -1,14 +1,9 @@
 import { addBooleanParameter } from "@ovh-ui/common/component-utils";
-import template from "./header-tabs-item.html";
 
 export default class {
     /* @ngInject */
-    constructor ($attrs, $compile, $element, $scope, $timeout) {
+    constructor ($attrs) {
         this.$attrs = $attrs;
-        this.$compile = $compile;
-        this.$element = $element;
-        this.$scope = $scope;
-        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -20,12 +15,6 @@ export default class {
             this.linkTarget = "_blank";
             this.linkRel = "noopener";
         }
-    }
-
-    $postLink () {
-        this.$compile(template)(this.$scope, clone => {
-            this.$element.replaceWith(clone);
-        });
     }
 
     // Return value of "ui-sref"


### PR DESCRIPTION
In some cases, the use of `replaceWith` cause duplication when associated with a `ngRepeat`.
It has no other purpose than keeping the same HTML structure as the style example [here](https://ovh-ux.github.io/ovh-ui-kit-documentation/#!/ovh-ui-kit/header-tabs).

The style has been updated in another PR: https://github.com/ovh-ux/ovh-ui-kit/pull/523