### PR TITLE
Revert "fix(oui-header-tabs): remove replaceWith that cause item duplication (#432)"

### DIFF
--- a/packages/oui-header-tabs/src/header-tabs-item.controller.js
+++ b/packages/oui-header-tabs/src/header-tabs-item.controller.js
@@ -1,9 +1,14 @@
 import { addBooleanParameter } from "@ovh-ui/common/component-utils";
+import template from "./header-tabs-item.html";
 
 export default class {
     /* @ngInject */
-    constructor ($attrs) {
+    constructor ($attrs, $compile, $element, $scope, $timeout) {
         this.$attrs = $attrs;
+        this.$compile = $compile;
+        this.$element = $element;
+        this.$scope = $scope;
+        this.$timeout = $timeout;
     }
 
     $onInit () {
@@ -15,6 +20,12 @@ export default class {
             this.linkTarget = "_blank";
             this.linkRel = "noopener";
         }
+    }
+
+    $postLink () {
+        this.$compile(template)(this.$scope, clone => {
+            this.$element.replaceWith(clone);
+        });
     }
 
     // Return value of "ui-sref"


### PR DESCRIPTION
This reverts commit 506a80112bf0343b74bd6f619c4f39df21731e98.

Due to the following error:

```js
angular.js:15567 TypeError: Cannot read property 'offsetLeft' of undefined
    at _class._scrollToItem (header-tabs.controller.js:104)
    at _class._scroll (header-tabs.controller.js:61)
    at _class.scrollRight (header-tabs.controller.js:47)
    at fn (eval at compile (angular.js:16418), <anonymous>:4:181)
    at callback (angular.js:28951)
    at Scope.$eval (angular.js:19393)
    at Scope.$apply (angular.js:19492)
    at HTMLButtonElement.<anonymous> (angular.js:28955)
    at defaultHandlerWrapper (angular.js:3824)
    at HTMLButtonElement.eventHandler (angular.js:3812)
```

cc @AxelPeter @marie-j 