### PR TITLE
fix(oui-dropdown): afterClose should remove the focus

### DIFF
--- a/packages/oui-dropdown/src/trigger/dropdown-trigger.controller.js
+++ b/packages/oui-dropdown/src/trigger/dropdown-trigger.controller.js
@@ -60,6 +60,7 @@ export default class {
 
     afterClose () {
         this.$trigger.attr("aria-expanded", false);
+        this.$trigger[0].blur();
         this.$trigger.off("keydown");
     }
 }


### PR DESCRIPTION
## `afterClose` should remove the focus

### Description of the Change

#### :bug: Bug Fix

fix(oui-dropdown): afterClose should remove the focus

### Benefits

Focus of the element is correctly removed by using [`.blur()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/blur).

### Possible Drawbacks

None.

### Applicable Issues

None.

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
