### PR TITLE
fix(oui-datagrid): use lodash get to check properties

### DIFF
--- a/packages/oui-datagrid/src/util.js
+++ b/packages/oui-datagrid/src/util.js
@@ -1,11 +1,6 @@
+import get from "lodash/get";
+import isUndefined from "lodash/isUndefined";
+
 export function hasProperty (obj, prop = "") {
-    const props = prop.split(".");
-    let theObject = obj;
-    for (let i = 0; i < props.length; i++) {
-        if (!Object.prototype.hasOwnProperty.call(theObject, props[i])) {
-            return false;
-        }
-        theObject = theObject[props[i]] || {};
-    }
-    return true;
+    return !isUndefined(get(obj, prop));
 }


### PR DESCRIPTION
This allow to also use getters as properties

fixes #448
